### PR TITLE
fix(mcp): add missing fields to Implementation struct initialization

### DIFF
--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -367,7 +367,7 @@ impl ServerHandler for JwtHackServer {
                 name: "jwt-hack".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
                 title: Some("JWT-HACK".to_string()),
-                website_url: None,
+                website_url: Some(env!("CARGO_PKG_REPOSITORY").to_string()),
                 icons: None,
             },
             instructions: Some("JWT-HACK MCP Server - Provides tools for JWT security testing including decode, encode, verify, crack, and payload generation.".to_string()),

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -366,6 +366,9 @@ impl ServerHandler for JwtHackServer {
             server_info: Implementation {
                 name: "jwt-hack".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
+                title: Some("JWT-HACK".to_string()),
+                website_url: None,
+                icons: None,
             },
             instructions: Some("JWT-HACK MCP Server - Provides tools for JWT security testing including decode, encode, verify, crack, and payload generation.".to_string()),
         }


### PR DESCRIPTION
closes #76

- https://github.com/Homebrew/homebrew-core/pull/239403