### PR TITLE
🧹 Refactor hardcoded common secrets to centralized constant

### DIFF
--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -255,7 +255,7 @@ impl JwtHackServer {
         // since we can't reliably access wordlist files
         if args.mode == "dict" {
             // Use a built-in small wordlist for demo purposes
-            let common_passwords = vec!["secret", "password", "123456", "admin", "test", "jwt"];
+            let common_passwords = crate::config::COMMON_SECRETS;
 
             for password in common_passwords {
                 if let Ok(is_valid) = crate::jwt::verify(&args.token, password) {

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -225,28 +225,7 @@ fn check_weak_secret(
     }
 
     // Use provided wordlist or common passwords
-    let common_secrets = vec![
-        "",
-        "secret",
-        "password",
-        "1234",
-        "123456",
-        "admin",
-        "test",
-        "key",
-        "jwt",
-        "token",
-        "your-256-bit-secret",
-        "your-secret",
-        "mysecret",
-        "default",
-        "changeme",
-        "qwerty",
-        "abc123",
-        "letmein",
-        "welcome",
-        "monkey",
-    ];
+    let common_secrets = crate::config::COMMON_SECRETS;
 
     let secrets_to_test: Vec<String> = if let Some(ref wordlist_path) = options.wordlist {
         // Read from wordlist file (limited to max_crack_attempts)

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,30 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Common secrets for dictionary attacks
+pub const COMMON_SECRETS: &[&str] = &[
+    "",
+    "secret",
+    "password",
+    "1234",
+    "123456",
+    "admin",
+    "test",
+    "key",
+    "jwt",
+    "token",
+    "your-256-bit-secret",
+    "your-secret",
+    "mysecret",
+    "default",
+    "changeme",
+    "qwerty",
+    "abc123",
+    "letmein",
+    "welcome",
+    "monkey",
+];
+
 /// Configuration structure for jwt-hack
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {


### PR DESCRIPTION
This PR improves code health by moving a hardcoded list of common secrets used for dictionary attacks from `src/cmd/scan.rs` to a centralized constant in `src/config.rs`. This change also consolidates a similar hardcoded list found in `src/cmd/mcp.rs`, ensuring consistency across the application.

🎯 **What:** Centralized hardcoded common secrets into a single constant.
💡 **Why:** Improves maintainability, reduces duplication, and makes it easier to update the list of common secrets used for security testing.
✅ **Verification:** Changes were verified by code review and manual inspection of the source code. Local testing was attempted but limited by environment restrictions.
✨ **Result:** Cleaner code structure and improved consistency between scanning and MCP tools.

---
*PR created automatically by Jules for task [1502868974774559421](https://jules.google.com/task/1502868974774559421) started by @hahwul*