### PR TITLE
🧪 Add test for JwtError Display implementation

### DIFF
--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -1659,4 +1659,16 @@ mod tests {
             "Generated JWE token should be decodable"
         );
     }
+
+    #[test]
+    fn test_jwt_error_display() {
+        assert_eq!(JwtError::InvalidSignature.to_string(), "Invalid signature");
+        assert_eq!(JwtError::ExpiredSignature.to_string(), "Expired signature");
+        assert_eq!(JwtError::ImmatureSignature.to_string(), "Immature signature");
+        assert_eq!(JwtError::InvalidAlgorithm.to_string(), "Invalid algorithm");
+        assert_eq!(
+            JwtError::Other("test error".to_string()).to_string(),
+            "JWT error: test error"
+        );
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify the `Display` implementation of the `JwtError` enum in `src/jwt/mod.rs`.
📊 **Coverage:** The test covers all variants of `JwtError` including `InvalidSignature`, `ExpiredSignature`, `ImmatureSignature`, `InvalidAlgorithm`, and `Other`.
✨ **Result:** Ensures that error messages are formatted as expected, preventing regressions in error reporting.

---
*PR created automatically by Jules for task [2401326346801629009](https://jules.google.com/task/2401326346801629009) started by @hahwul*