### PR TITLE
ci(homebrew): fix Ruby interpolation in formula test block

### DIFF
--- a/.github/workflows/cd-homebrew-tap.yml
+++ b/.github/workflows/cd-homebrew-tap.yml
@@ -22,7 +22,7 @@ jobs:
           install: |
             system "cargo build --release"
             bin.install "target/release/jwt-hack"
-          test: system "{bin}/jwt-hack", "-V"
+          test: system "#{bin}/jwt-hack", "-V"
           update_readme_table: true
           skip_commit: false
           debug: false


### PR DESCRIPTION
## Summary
- The current homebrew-releaser config emits a formula whose `test` block reads `system "{bin}/jwt-hack", "-V"` — a literal path, which breaks `brew test` and `brew audit`.
- Switched to `#{bin}` so Homebrew interpolates the formula's bin path.
- Next published release will regenerate `Formula/jwt-hack.rb` correctly.

Same fix as hahwul/hwaro#518 — caught while sweeping siblings for the same pattern.

## Test plan
- [ ] After next release, verify the published formula contains `system "#{bin}/jwt-hack", "-V"` and `brew test jwt-hack` succeeds