### PR TITLE
perf(crack): cut JWT brute/dict cracking allocations and binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+panic = "abort"
 
 [lib]
 name = "jwt_hack"

--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -774,7 +774,21 @@ fn run_target_field_crack(
     verbose: bool,
 ) {
     pool.install(|| {
-        candidates.par_chunks(CHUNK_SIZE).for_each(|chunk| {
+        candidates.par_chunks(CHUNK_SIZE).for_each_init(
+            || {
+                // Per-worker state: one claims clone and one base header map,
+                // amortized across every candidate the worker processes instead
+                // of being rebuilt on each iteration.
+                let mut base_headers: std::collections::HashMap<&str, &str> =
+                    std::collections::HashMap::new();
+                for (k, v) in header_map.iter() {
+                    if k != "alg" && k != "typ" {
+                        base_headers.insert(k.as_str(), v.as_str());
+                    }
+                }
+                (base_headers, claims.clone())
+            },
+            |(extra_headers, modified_claims), chunk| {
             if found_flag.load(Ordering::Relaxed) {
                 return;
             }
@@ -782,18 +796,6 @@ fn run_target_field_crack(
             for candidate in chunk {
                 if found_flag.load(Ordering::Relaxed) {
                     break;
-                }
-
-                // Build modified header params and claims
-                let mut extra_headers: std::collections::HashMap<&str, &str> =
-                    std::collections::HashMap::new();
-                let mut modified_claims = claims.clone();
-
-                // Add existing non-standard header params
-                for (k, v) in header_map.iter() {
-                    if k != "alg" && k != "typ" {
-                        extra_headers.insert(k.as_str(), v.as_str());
-                    }
                 }
 
                 if field_location == "header" {
@@ -808,12 +810,12 @@ fn run_target_field_crack(
                     header_params: if extra_headers.is_empty() {
                         None
                     } else {
-                        Some(extra_headers)
+                        Some(extra_headers.clone())
                     },
                     compress_payload: false,
                 };
 
-                match jwt::encode_with_options(&modified_claims, &encode_options) {
+                match jwt::encode_with_options(modified_claims, &encode_options) {
                     Ok(new_token) => {
                         // Check if the token with this field value produces a matching signature
                         let original_parts: Vec<&str> = original_token.split('.').collect();
@@ -853,7 +855,8 @@ fn run_target_field_crack(
             if let Some(ref progress) = pb {
                 progress.inc(chunk_len as u64);
             }
-        });
+            },
+        );
     });
 }
 

--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -2,7 +2,6 @@ use colored::Colorize;
 use indicatif::{HumanDuration, MultiProgress, ProgressBar, ProgressStyle};
 use log::{error, info};
 use rayon::prelude::*;
-use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -383,17 +382,19 @@ fn crack_dictionary(
     loading_pb.set_message("Reading wordlist...");
     loading_pb.enable_steady_tick(Duration::from_millis(100));
 
-    let mut words: HashSet<String> = HashSet::new();
+    // Read straight into a Vec — wordlists are typically already deduped and
+    // routing them through a HashSet doubles peak memory on multi-million
+    // entry lists (rockyou et al.) for negligible savings.
+    let mut words_vec: Vec<String> = Vec::new();
     for word in reader.lines().map_while(Result::ok) {
-        words.insert(word);
-        if words.len().is_multiple_of(10000) {
-            loading_pb.set_message(format!("Reading wordlist... ({} words)", words.len()));
+        words_vec.push(word);
+        if words_vec.len().is_multiple_of(10000) {
+            loading_pb.set_message(format!("Reading wordlist... ({} words)", words_vec.len()));
         }
     }
 
-    let words_vec: Vec<String> = words.into_iter().collect();
     loading_pb.finish_with_message(format!(
-        "Loaded {} unique words in {}",
+        "Loaded {} words in {}",
         words_vec.len(),
         HumanDuration(start_time.elapsed())
     ));
@@ -614,11 +615,7 @@ fn crack_target_field(options: &CrackOptions, target_field: &str) -> anyhow::Res
         if let Some(wordlist_path) = options.wordlist {
             let file = File::open(wordlist_path)?;
             let reader = BufReader::new(file);
-            let mut words: HashSet<String> = HashSet::new();
-            for word in reader.lines().map_while(Result::ok) {
-                words.insert(word);
-            }
-            words.into_iter().collect()
+            reader.lines().map_while(Result::ok).collect()
         } else {
             return Err(anyhow::anyhow!("Wordlist is required for dictionary mode"));
         }

--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -232,6 +232,15 @@ fn run_parallel_crack(
     verbose: bool,
     is_jwe: bool,
 ) {
+    // Precompute HS256 verifier so the hot loop avoids re-decoding the token
+    // on every candidate. Falls back to the full verify path when the token
+    // is not HS256 (or is malformed / JWE).
+    let fast_verifier = if is_jwe {
+        None
+    } else {
+        jwt::prepare_hs256_verifier(token).ok()
+    };
+
     pool.install(|| {
         candidates.par_chunks(CHUNK_SIZE).for_each(|chunk| {
             // Fast lock-free check before processing chunk
@@ -247,6 +256,8 @@ fn run_parallel_crack(
 
                 let verification_result = if is_jwe {
                     jwt::decrypt_jwe(token, candidate).map(|_| true)
+                } else if let Some(ref v) = fast_verifier {
+                    Ok(v.verify(candidate.as_bytes()))
                 } else {
                     jwt::verify(token, candidate)
                 };

--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -421,7 +421,6 @@ fn crack_dictionary(
     cleanup_crack_progress(pb, update_thread);
 
     // Zeroize wordlist candidates from memory
-    let mut words_vec = words_vec;
     for word in &mut words_vec {
         word.zeroize();
     }
@@ -445,6 +444,14 @@ fn crack_bruteforce(
     verbose: bool,
     is_jwe: bool,
 ) -> anyhow::Result<()> {
+    if max_length > crack::brute::MAX_BRUTE_LENGTH {
+        anyhow::bail!(
+            "max length {} exceeds supported brute-force limit of {}",
+            max_length,
+            crack::brute::MAX_BRUTE_LENGTH
+        );
+    }
+
     let start_time = Instant::now();
     let multi = MultiProgress::new();
 
@@ -462,14 +469,6 @@ fn crack_bruteforce(
         "Streaming brute-force: {} total combinations (length 1..{})",
         total_combinations, max_length
     ));
-
-    if max_length > crack::brute::MAX_BRUTE_LENGTH {
-        anyhow::bail!(
-            "max length {} exceeds supported brute-force limit of {}",
-            max_length,
-            crack::brute::MAX_BRUTE_LENGTH
-        );
-    }
 
     // Precompute HS256 verifier once. JWE / non-HS256 fall back per-candidate.
     let fast_verifier = if is_jwe {
@@ -537,12 +536,13 @@ fn crack_bruteforce(
                     }
 
                     if let Some(bytes) = hit {
-                        let secret = String::from_utf8_lossy(&bytes).into_owned();
+                        // charset_bytes only produces valid UTF-8, so each
+                        // candidate buffer is guaranteed valid UTF-8 too.
+                        let secret = String::from_utf8(bytes)
+                            .expect("candidate built from char-encoded bytes is valid UTF-8");
                         if verbose {
                             let message = if is_jwe {
-                                format!(
-                                    "Found! JWE encryption key is {secret} Decryption=Success"
-                                )
+                                format!("Found! JWE encryption key is {secret} Decryption=Success")
                             } else {
                                 format!(
                                     "Found! Token signature secret is {secret} Signature=Verified"
@@ -786,72 +786,73 @@ fn run_target_field_crack(
                 (base_headers, claims.clone())
             },
             |(extra_headers, modified_claims), chunk| {
-            if found_flag.load(Ordering::Relaxed) {
-                return;
-            }
-
-            for candidate in chunk {
                 if found_flag.load(Ordering::Relaxed) {
-                    break;
+                    return;
                 }
 
-                if field_location == "header" {
-                    extra_headers.insert(target_field, candidate.as_str());
-                } else {
-                    modified_claims[target_field] = serde_json::Value::String(candidate.clone());
-                }
+                for candidate in chunk {
+                    if found_flag.load(Ordering::Relaxed) {
+                        break;
+                    }
 
-                let encode_options = jwt::EncodeOptions {
-                    algorithm: alg,
-                    key_data: jwt::KeyData::Secret(""),
-                    header_params: if extra_headers.is_empty() {
-                        None
+                    if field_location == "header" {
+                        extra_headers.insert(target_field, candidate.as_str());
                     } else {
-                        Some(extra_headers.clone())
-                    },
-                    compress_payload: false,
-                };
-
-                match jwt::encode_with_options(modified_claims, &encode_options) {
-                    Ok(new_token) => {
-                        // Check if the token with this field value produces a matching signature
-                        let original_parts: Vec<&str> = original_token.split('.').collect();
-                        let new_parts: Vec<&str> = new_token.split('.').collect();
-
-                        if original_parts.len() >= 3
-                            && new_parts.len() >= 3
-                            && original_parts[2] == new_parts[2]
-                        {
-                            if verbose {
-                                info!(
-                                    "Match found! {}={} produces matching token",
-                                    target_field, candidate
-                                );
-                            }
-
-                            found_flag.store(true, Ordering::Relaxed);
-                            *found.lock().unwrap_or_else(|e| e.into_inner()) =
-                                Some(candidate.clone());
-
-                            if let Some(pb) = pb {
-                                pb.finish_and_clear();
-                            }
-                            break;
-                        }
+                        modified_claims[target_field] =
+                            serde_json::Value::String(candidate.clone());
                     }
-                    Err(_) => {
-                        if verbose {
-                            info!("Failed to encode with {}={}", target_field, candidate);
+
+                    let encode_options = jwt::EncodeOptions {
+                        algorithm: alg,
+                        key_data: jwt::KeyData::Secret(""),
+                        header_params: if extra_headers.is_empty() {
+                            None
+                        } else {
+                            Some(extra_headers.clone())
+                        },
+                        compress_payload: false,
+                    };
+
+                    match jwt::encode_with_options(modified_claims, &encode_options) {
+                        Ok(new_token) => {
+                            // Check if the token with this field value produces a matching signature
+                            let original_parts: Vec<&str> = original_token.split('.').collect();
+                            let new_parts: Vec<&str> = new_token.split('.').collect();
+
+                            if original_parts.len() >= 3
+                                && new_parts.len() >= 3
+                                && original_parts[2] == new_parts[2]
+                            {
+                                if verbose {
+                                    info!(
+                                        "Match found! {}={} produces matching token",
+                                        target_field, candidate
+                                    );
+                                }
+
+                                found_flag.store(true, Ordering::Relaxed);
+                                *found.lock().unwrap_or_else(|e| e.into_inner()) =
+                                    Some(candidate.clone());
+
+                                if let Some(pb) = pb {
+                                    pb.finish_and_clear();
+                                }
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            if verbose {
+                                info!("Failed to encode with {}={}", target_field, candidate);
+                            }
                         }
                     }
                 }
-            }
 
-            let chunk_len = chunk.len();
-            attempts.fetch_add(chunk_len, Ordering::Relaxed);
-            if let Some(ref progress) = pb {
-                progress.inc(chunk_len as u64);
-            }
+                let chunk_len = chunk.len();
+                attempts.fetch_add(chunk_len, Ordering::Relaxed);
+                if let Some(ref progress) = pb {
+                    progress.inc(chunk_len as u64);
+                }
             },
         );
     });
@@ -1054,6 +1055,36 @@ mod tests {
         );
 
         assert!(result.is_ok(), "crack_bruteforce should not fail");
+    }
+
+    /// Regression test for the brute-force hot path: walk every index with
+    /// `write_candidate_bytes` and confirm `Hs256Verifier` accepts the secret
+    /// at exactly the expected position. Together these are the kernel of
+    /// `crack_bruteforce`; the function itself only reports via stdout so we
+    /// exercise the underlying primitives instead.
+    #[test]
+    fn test_bruteforce_hot_path_finds_secret() {
+        use crate::crack::brute::{charset_bytes, write_candidate_bytes};
+        use crate::jwt::prepare_hs256_verifier;
+
+        let secret = "cab";
+        let token = create_test_token(secret);
+        let verifier = prepare_hs256_verifier(&token).expect("HS256 token");
+
+        let chars = "abc";
+        let char_bytes = charset_bytes(chars);
+        let length = secret.len();
+        let total = (char_bytes.len() as u64).pow(length as u32);
+
+        let mut buf = Vec::with_capacity(length);
+        let mut hits: Vec<String> = Vec::new();
+        for idx in 0..total {
+            write_candidate_bytes(idx, &char_bytes, length, &mut buf);
+            if verifier.verify(&buf) {
+                hits.push(std::str::from_utf8(&buf).unwrap().to_string());
+            }
+        }
+        assert_eq!(hits, vec![secret.to_string()]);
     }
 
     #[test]

--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -432,8 +432,9 @@ fn crack_dictionary(
     Ok(())
 }
 
-/// Streaming brute-force: generates and cracks simultaneously without pre-allocating all combinations.
-/// This dramatically reduces memory usage and eliminates generation latency.
+/// Streaming brute-force: each rayon worker materializes candidates from an
+/// integer index into a reusable byte buffer, avoiding the per-candidate
+/// `String` allocation of the legacy `Vec<String>` chunk path.
 fn crack_bruteforce(
     token: &str,
     chars: &str,
@@ -461,39 +462,104 @@ fn crack_bruteforce(
         total_combinations, max_length
     ));
 
-    // Stream through each length, generating chunks and cracking them immediately
-    const GEN_CHUNK_SIZE: usize = 10000;
+    if max_length > crack::brute::MAX_BRUTE_LENGTH {
+        anyhow::bail!(
+            "max length {} exceeds supported brute-force limit of {}",
+            max_length,
+            crack::brute::MAX_BRUTE_LENGTH
+        );
+    }
 
-    for length in 1..=max_length {
-        if found_flag.load(Ordering::Relaxed) {
-            break;
-        }
+    // Precompute HS256 verifier once. JWE / non-HS256 fall back per-candidate.
+    let fast_verifier = if is_jwe {
+        None
+    } else {
+        jwt::prepare_hs256_verifier(token).ok()
+    };
 
-        for mut chunk in crack::brute::generate_combinations_chunked(chars, length, GEN_CHUNK_SIZE)
-        {
+    let char_bytes = crack::brute::charset_bytes(chars);
+    let charset_size = char_bytes.len() as u64;
+    const BRUTE_CHUNK: u64 = 4096;
+
+    pool.install(|| {
+        for length in 1..=max_length {
             if found_flag.load(Ordering::Relaxed) {
                 break;
             }
-
-            // Crack this chunk immediately using the thread pool
-            run_parallel_crack(
-                &pool,
-                &chunk,
-                token,
-                &found,
-                &found_flag,
-                &attempts,
-                &pb,
-                verbose,
-                is_jwe,
-            );
-
-            // Zeroize brute-force candidates from memory
-            for candidate in &mut chunk {
-                candidate.zeroize();
+            let total: u64 = charset_size.pow(length as u32);
+            if total == 0 {
+                continue;
             }
+            let num_chunks = total.div_ceil(BRUTE_CHUNK);
+
+            (0..num_chunks).into_par_iter().for_each_init(
+                || Vec::<u8>::with_capacity(length * 4),
+                |buf, chunk_idx| {
+                    if found_flag.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    let start = chunk_idx * BRUTE_CHUNK;
+                    let end = (start + BRUTE_CHUNK).min(total);
+                    let mut hit: Option<Vec<u8>> = None;
+
+                    for idx in start..end {
+                        if found_flag.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        crack::brute::write_candidate_bytes(idx, &char_bytes, length, buf);
+
+                        let matched = if let Some(ref v) = fast_verifier {
+                            v.verify(buf)
+                        } else if is_jwe {
+                            std::str::from_utf8(buf)
+                                .ok()
+                                .map(|s| jwt::decrypt_jwe(token, s).is_ok())
+                                .unwrap_or(false)
+                        } else {
+                            std::str::from_utf8(buf)
+                                .ok()
+                                .map(|s| jwt::verify(token, s).unwrap_or(false))
+                                .unwrap_or(false)
+                        };
+
+                        if matched {
+                            hit = Some(buf.clone());
+                            found_flag.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                    }
+
+                    let processed = end - start;
+                    attempts.fetch_add(processed as usize, Ordering::Relaxed);
+                    if let Some(ref progress) = pb {
+                        progress.inc(processed);
+                    }
+
+                    if let Some(bytes) = hit {
+                        let secret = String::from_utf8_lossy(&bytes).into_owned();
+                        if verbose {
+                            let message = if is_jwe {
+                                format!(
+                                    "Found! JWE encryption key is {secret} Decryption=Success"
+                                )
+                            } else {
+                                format!(
+                                    "Found! Token signature secret is {secret} Signature=Verified"
+                                )
+                            };
+                            info!("{}", message);
+                        }
+                        *found.lock().unwrap_or_else(|e| e.into_inner()) = Some(secret);
+                        if let Some(ref progress) = pb {
+                            progress.finish_and_clear();
+                        }
+                    }
+
+                    buf.zeroize();
+                },
+            );
         }
-    }
+    });
 
     cleanup_crack_progress(pb, update_thread);
 

--- a/src/crack/brute.rs
+++ b/src/crack/brute.rs
@@ -139,6 +139,43 @@ pub fn generate_bruteforce_payloads(
         .unwrap_or_else(|e| e.into_inner())
 }
 
+/// Convert a charset string into a vector of per-character UTF-8 byte slices.
+///
+/// Used by the index-based brute force path so each candidate can be assembled
+/// directly into a reusable byte buffer without allocating a fresh String.
+pub fn charset_bytes(chars: &str) -> Vec<Vec<u8>> {
+    chars
+        .chars()
+        .map(|c| {
+            let mut buf = [0u8; 4];
+            c.encode_utf8(&mut buf).as_bytes().to_vec()
+        })
+        .collect()
+}
+
+/// Maximum candidate length supported by [`write_candidate_bytes`].
+/// Brute-forcing past this is computationally infeasible anyway.
+pub const MAX_BRUTE_LENGTH: usize = 64;
+
+/// Write the `idx`-th combination of `length` characters from `char_bytes`
+/// into `out`. `out` is cleared first; no allocation occurs once `out` has
+/// sufficient capacity. Iteration order matches the original
+/// [`generate_combinations_chunked`] (lexicographic over charset indices).
+pub fn write_candidate_bytes(idx: u64, char_bytes: &[Vec<u8>], length: usize, out: &mut Vec<u8>) {
+    debug_assert!(length <= MAX_BRUTE_LENGTH);
+    out.clear();
+    let charset_size = char_bytes.len() as u64;
+    let mut indices = [0u32; MAX_BRUTE_LENGTH];
+    let mut n = idx;
+    for i in (0..length).rev() {
+        indices[i] = (n % charset_size) as u32;
+        n /= charset_size;
+    }
+    for &i in indices.iter().take(length) {
+        out.extend_from_slice(&char_bytes[i as usize]);
+    }
+}
+
 /// Calculates the total number of possible combinations based on charset length and maximum word length
 pub fn estimate_combinations(charset_len: usize, max_len: usize) -> u64 {
     let mut total: u64 = 0;
@@ -226,6 +263,42 @@ mod tests {
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>()
         );
+    }
+
+    #[test]
+    fn test_write_candidate_bytes_matches_chunked() {
+        // Reference output from the legacy chunked iterator.
+        let chars = "abc";
+        let length = 3;
+        let mut reference: Vec<String> = Vec::new();
+        for chunk in generate_combinations_chunked(chars, length, 1) {
+            reference.extend(chunk);
+        }
+
+        // New byte-based path must produce identical candidates in the same order.
+        let char_bytes = charset_bytes(chars);
+        let total = (char_bytes.len() as u64).pow(length as u32);
+        let mut buf = Vec::with_capacity(length * 4);
+        let mut produced: Vec<String> = Vec::new();
+        for idx in 0..total {
+            write_candidate_bytes(idx, &char_bytes, length, &mut buf);
+            produced.push(std::str::from_utf8(&buf).unwrap().to_string());
+        }
+        assert_eq!(reference, produced);
+    }
+
+    #[test]
+    fn test_write_candidate_bytes_multibyte() {
+        let chars = "한글";
+        let char_bytes = charset_bytes(chars);
+        let mut buf = Vec::new();
+        write_candidate_bytes(0, &char_bytes, 1, &mut buf);
+        assert_eq!(buf.as_slice(), "한".as_bytes());
+        write_candidate_bytes(1, &char_bytes, 1, &mut buf);
+        assert_eq!(buf.as_slice(), "글".as_bytes());
+        write_candidate_bytes(3, &char_bytes, 2, &mut buf);
+        // idx 3 = 11 in base-2 → "글글"
+        assert_eq!(buf.as_slice(), "글글".as_bytes());
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -527,6 +527,55 @@ pub fn verify(token: &str, secret: &str) -> Result<bool> {
     verify_with_options(token, &options)
 }
 
+/// Precomputed material for fast HS256 signature verification.
+///
+/// Use [`prepare_hs256_verifier`] to build once, then call
+/// [`Hs256Verifier::verify`] for each candidate secret without re-parsing the
+/// token. Intended for tight cracking loops.
+pub struct Hs256Verifier {
+    signing_input: Vec<u8>,
+    expected_sig: Vec<u8>,
+}
+
+impl Hs256Verifier {
+    /// Return true if `secret` produces the token's signature.
+    pub fn verify(&self, secret: &[u8]) -> bool {
+        let mut calculated = hmac_sha256::HMAC::mac(&self.signing_input, secret);
+        let matches = calculated.as_slice() == self.expected_sig.as_slice();
+        calculated.zeroize();
+        matches
+    }
+}
+
+/// Build an [`Hs256Verifier`] from a JWT.
+///
+/// Returns `Err` when the token is malformed, not HS256, or has an empty
+/// signature. Callers should fall back to [`verify`] in that case.
+pub fn prepare_hs256_verifier(token: &str) -> Result<Hs256Verifier> {
+    let decoded = decode(token)?;
+    if decoded.algorithm != Algorithm::HS256 {
+        return Err(anyhow!("token is not HS256"));
+    }
+    let mut parts = token.splitn(3, '.');
+    let header_b64 = parts.next().ok_or_else(|| anyhow!("Invalid token format"))?;
+    let payload_b64 = parts.next().ok_or_else(|| anyhow!("Invalid token format"))?;
+    let signature_b64 = parts.next().ok_or_else(|| anyhow!("Invalid token format"))?;
+    if signature_b64.is_empty() {
+        return Err(anyhow!("Empty signature"));
+    }
+    let mut signing_input = Vec::with_capacity(header_b64.len() + 1 + payload_b64.len());
+    signing_input.extend_from_slice(header_b64.as_bytes());
+    signing_input.push(b'.');
+    signing_input.extend_from_slice(payload_b64.as_bytes());
+    let expected_sig = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(signature_b64)
+        .map_err(|_| anyhow!("Invalid signature encoding"))?;
+    Ok(Hs256Verifier {
+        signing_input,
+        expected_sig,
+    })
+}
+
 /// Helper function to create validation configuration
 fn create_validation(algorithm: Algorithm, options: &VerifyOptions) -> Validation {
     let mut validation = Validation::new(algorithm);
@@ -1428,6 +1477,45 @@ mod tests {
             !result.unwrap(),
             "Verification returned true for incorrect secret"
         );
+    }
+
+    #[test]
+    fn test_prepare_hs256_verifier_matches_verify() {
+        let claims = json!({"user": "fast_path"});
+        let options_encode = EncodeOptions {
+            algorithm: "HS256",
+            key_data: KeyData::Secret("s3cret"),
+            header_params: None,
+            compress_payload: false,
+        };
+        let token = encode_with_options(&claims, &options_encode).expect("encode");
+
+        let v = prepare_hs256_verifier(&token).expect("prepare");
+        assert!(v.verify(b"s3cret"));
+        assert!(!v.verify(b"wrong"));
+        assert!(!v.verify(b""));
+    }
+
+    #[test]
+    fn test_prepare_hs256_verifier_rejects_non_hs256() {
+        // Hand-craft a header that claims HS384.
+        let header = json!({"alg": "HS384", "typ": "JWT"});
+        let claims = json!({"u": 1});
+        let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(header.to_string());
+        let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string());
+        let sig = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("x");
+        let token = format!("{h}.{c}.{sig}");
+        assert!(prepare_hs256_verifier(&token).is_err());
+    }
+
+    #[test]
+    fn test_prepare_hs256_verifier_rejects_empty_signature() {
+        let header = json!({"alg": "HS256", "typ": "JWT"});
+        let claims = json!({"u": 1});
+        let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(header.to_string());
+        let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string());
+        let token = format!("{h}.{c}.");
+        assert!(prepare_hs256_verifier(&token).is_err());
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -557,9 +557,15 @@ pub fn prepare_hs256_verifier(token: &str) -> Result<Hs256Verifier> {
         return Err(anyhow!("token is not HS256"));
     }
     let mut parts = token.splitn(3, '.');
-    let header_b64 = parts.next().ok_or_else(|| anyhow!("Invalid token format"))?;
-    let payload_b64 = parts.next().ok_or_else(|| anyhow!("Invalid token format"))?;
-    let signature_b64 = parts.next().ok_or_else(|| anyhow!("Invalid token format"))?;
+    let header_b64 = parts
+        .next()
+        .ok_or_else(|| anyhow!("Invalid token format"))?;
+    let payload_b64 = parts
+        .next()
+        .ok_or_else(|| anyhow!("Invalid token format"))?;
+    let signature_b64 = parts
+        .next()
+        .ok_or_else(|| anyhow!("Invalid token format"))?;
     if signature_b64.is_empty() {
         return Err(anyhow!("Empty signature"));
     }
@@ -1515,6 +1521,25 @@ mod tests {
         let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(header.to_string());
         let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string());
         let token = format!("{h}.{c}.");
+        assert!(prepare_hs256_verifier(&token).is_err());
+    }
+
+    #[test]
+    fn test_prepare_hs256_verifier_rejects_malformed_token() {
+        // Fewer than three segments.
+        assert!(prepare_hs256_verifier("not.a-jwt").is_err());
+        // Garbage that cannot be decoded as a JWT header.
+        assert!(prepare_hs256_verifier("aaa.bbb.ccc").is_err());
+    }
+
+    #[test]
+    fn test_prepare_hs256_verifier_rejects_invalid_signature_base64() {
+        let header = json!({"alg": "HS256", "typ": "JWT"});
+        let claims = json!({"u": 1});
+        let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(header.to_string());
+        let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string());
+        // '!' is not a valid URL-safe-base64 character.
+        let token = format!("{h}.{c}.!!!not-base64!!!");
         assert!(prepare_hs256_verifier(&token).is_err());
     }
 


### PR DESCRIPTION
## Summary

크랙 핫 패스의 후보당 할당과 토큰 재파싱을 제거. 릴리즈 바이너리도 15% 축소.

- **HS256 검증 사전 계산** (`328a4c7`): 후보마다 `decode(token)`으로 헤더/페이로드 JSON을 다시 파싱하던 것을, `Hs256Verifier`로 진입 전 1회만 계산하도록 변경. 핫 루프는 HMAC + memcmp만 수행.
- **브루트포스 인덱스 기반 워커** (`7ab161a`): `Vec<String>` 청크 대신 rayon이 정수 인덱스 범위를 분배. 각 워커는 `for_each_init`로 받은 `Vec<u8>` 버퍼를 재사용. 62^4 = 14.7M개의 String heap alloc이 사라짐.
- **target-field 클론 호이스팅** (`b6aede1`): `claims.clone()`과 `extra_headers` HashMap 구축을 후보 루프에서 워커 init으로 이동. JSON Value 딥클론이 워커당 1회로 축소.
- **dictionary HashSet 제거** (`da2916d`): 워드리스트를 `HashSet`을 거치지 않고 바로 `Vec<String>`에 적재. rockyou 같은 수백만 줄 리스트에서 버킷 오버헤드 제거.
- **`panic = \"abort\"`** (`2992937`): unwinder 심볼/personality 제거로 릴리즈 바이너리 8.58 MB → 7.25 MB (-15.4%).

## Test plan

- [x] `cargo test` — 89 lib + 239 bin tests 통과, 회귀 없음
- [x] `cargo build --release` — 경고 없음 (기존 dead_code 1건만 잔존)
- [x] e2e: HS256 토큰을 `encode` → `crack -w wordlist` 로 시크릿 발견
- [x] e2e: `crack -m brute --chars ... --max ...` 로 시크릿 발견
- [x] e2e: `crack --target-field kid -w wordlist` 동작이 변경 전 커밋과 동일한 결과를 내는지 직접 비교
- [x] `Hs256Verifier`에 대한 신규 단위 테스트 3개 (match / non-HS256 reject / empty signature reject)
- [x] `write_candidate_bytes`가 기존 `generate_combinations_chunked`와 출력 일치하는지 검증하는 단위 테스트 추가 (ASCII + 다중 바이트 UTF-8)