### PR TITLE
docs: redesign documentation with Cipher Lab theme

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,7 +1,6 @@
 +++
 title = "JWT-HACK"
 template = "landing"
-hero_title = "Welcome to JWT-HACK!"
 hero_badge = "v2.5.0"
 hero_description = "A high-performance toolkit for testing, analyzing and attacking JSON Web Tokens"
 features_title = "Essential Features"

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1,70 +1,121 @@
 /* =============================================================================
-   JWT-HACK Documentation — Green Dark Theme (GitButler-style)
+   JWT-HACK Documentation — "Cipher Lab" Theme
+   ----------------------------------------------------------------------------
+   Identity:
+   - Three-segment JWT palette (red / violet / cyan) as recurring motif
+   - Neon-green brand accent for actions
+   - Midnight blue-black surface, dotted grid backdrop
+   - Editorial monospace headings, technical typography
    ============================================================================= */
 
-/* --- Google Fonts --- */
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
 
-/* --- Color Tokens --- */
+/* --- Brand & Palette ----------------------------------------------------- */
 :root {
-    --primary: #22c55e;
-    --primary-hover: #16a34a;
-    --primary-light: #86efac;
-    --primary-dark: #15803d;
-    --primary-subtle: rgba(34, 197, 94, 0.1);
-    --primary-border: rgba(34, 197, 94, 0.3);
+    /* Brand accent — neon lime */
+    --brand: #5eff9b;
+    --brand-hover: #34e879;
+    --brand-soft: rgba(94, 255, 155, 0.12);
+    --brand-line: rgba(94, 255, 155, 0.35);
+    --brand-glow: rgba(94, 255, 155, 0.45);
+
+    /* JWT segment palette */
+    --seg-header: #ff4d8d;     /* signed pink/red */
+    --seg-payload: #b18bff;    /* violet */
+    --seg-signature: #22d3ee;  /* cyan */
+    --seg-header-soft: rgba(255, 77, 141, 0.14);
+    --seg-payload-soft: rgba(177, 139, 255, 0.14);
+    --seg-signature-soft: rgba(34, 211, 238, 0.14);
+
+    /* Status */
+    --warn: #facc15;
+    --danger: #f87171;
+    --info: #60a5fa;
 }
 
 [data-theme="dark"] {
-    --bg-primary: #0a0a0a;
-    --bg-secondary: #111111;
-    --bg-tertiary: #1a1a1a;
-    --bg-card: #161616;
-    --bg-code: #0d0d0d;
-    --text-primary: #fafafa;
-    --text-secondary: #a1a1aa;
-    --text-muted: #71717a;
-    --border-color: #27272a;
-    --border-subtle: #1f1f23;
-    --header-bg: rgba(10, 10, 10, 0.8);
-    --sidebar-bg: #0f0f0f;
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+    --bg: #06080d;
+    --bg-surface: #0a0d15;
+    --bg-elev: #0f131c;
+    --bg-sunken: #04060a;
+    --bg-code: #05070b;
+
+    --fg: #e6e9ef;
+    --fg-soft: #a3a9b8;
+    --fg-mute: #6b7080;
+
+    --line: #161a25;
+    --line-strong: #1f2433;
+    --line-mute: #0e1119;
+
+    --header-bg: rgba(6, 8, 13, 0.72);
+    --sidebar-bg: #07090f;
+
+    --grid-dot: rgba(255, 255, 255, 0.045);
+    --glow-1: rgba(94, 255, 155, 0.08);
+    --glow-2: rgba(34, 211, 238, 0.06);
+
+    --shadow-card: 0 1px 0 rgba(255, 255, 255, 0.02) inset,
+        0 12px 32px -16px rgba(0, 0, 0, 0.7);
 }
 
 [data-theme="light"] {
-    --bg-primary: #ffffff;
-    --bg-secondary: #f9fafb;
-    --bg-tertiary: #f3f4f6;
-    --bg-card: #ffffff;
-    --bg-code: #f8f9fa;
-    --text-primary: #111827;
-    --text-secondary: #6b7280;
-    --text-muted: #9ca3af;
-    --border-color: #e5e7eb;
-    --border-subtle: #f3f4f6;
-    --header-bg: rgba(255, 255, 255, 0.8);
-    --sidebar-bg: #f9fafb;
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+    --bg: #fbfbfc;
+    --bg-surface: #ffffff;
+    --bg-elev: #ffffff;
+    --bg-sunken: #f4f5f8;
+    --bg-code: #f5f6f9;
+
+    --fg: #0c0e14;
+    --fg-soft: #4a5060;
+    --fg-mute: #8c92a3;
+
+    --line: #e6e8ee;
+    --line-strong: #d4d8e1;
+    --line-mute: #eef0f4;
+
+    --header-bg: rgba(255, 255, 255, 0.78);
+    --sidebar-bg: #f7f8fa;
+
+    --grid-dot: rgba(12, 14, 20, 0.06);
+    --glow-1: rgba(52, 232, 121, 0.07);
+    --glow-2: rgba(34, 211, 238, 0.05);
+
+    --brand: #00a85a;
+    --brand-hover: #008a4a;
+    --brand-soft: rgba(0, 168, 90, 0.1);
+    --brand-line: rgba(0, 168, 90, 0.3);
+    --brand-glow: rgba(0, 168, 90, 0.3);
+
+    --seg-header: #e23170;
+    --seg-payload: #7c5cff;
+    --seg-signature: #0aa7c6;
+    --seg-header-soft: rgba(226, 49, 112, 0.1);
+    --seg-payload-soft: rgba(124, 92, 255, 0.1);
+    --seg-signature-soft: rgba(10, 167, 198, 0.1);
+
+    --shadow-card: 0 1px 0 rgba(255, 255, 255, 0.6) inset,
+        0 12px 28px -18px rgba(15, 22, 36, 0.18);
 }
 
-/* --- Layout Tokens --- */
+/* --- Tokens -------------------------------------------------------------- */
 :root {
-    --header-h: 60px;
-    --sidebar-w: 280px;
-    --content-max-w: 820px;
-    --radius-sm: 6px;
+    --header-h: 56px;
+    --sidebar-w: 272px;
+    --content-max: 800px;
+    --radius-sm: 4px;
     --radius-md: 8px;
-    --radius-lg: 12px;
-    --radius-xl: 16px;
-    --transition-fast: 150ms ease;
-    --transition-normal: 250ms ease;
+    --radius-lg: 14px;
+    --t-fast: 120ms cubic-bezier(0.4, 0, 0.2, 1);
+    --t-mid: 240ms cubic-bezier(0.4, 0, 0.2, 1);
+
+    --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas,
+        monospace;
 }
 
-/* --- Reset --- */
+/* --- Reset & Base -------------------------------------------------------- */
 *,
 *::before,
 *::after {
@@ -73,57 +124,87 @@
     padding: 0;
 }
 
-/* --- Base --- */
 html {
     scroll-behavior: smooth;
     scroll-padding-top: calc(var(--header-h) + 1rem);
 }
 
 body {
-    font-family:
-        "Inter",
-        -apple-system,
-        BlinkMacSystemFont,
-        "Segoe UI",
-        Roboto,
-        sans-serif;
+    font-family: var(--font-sans);
     font-size: 15px;
     line-height: 1.7;
-    color: var(--text-primary);
-    background: var(--bg-primary);
+    color: var(--fg);
+    background: var(--bg);
+    background-image:
+        radial-gradient(var(--grid-dot) 1px, transparent 1px),
+        radial-gradient(
+            ellipse 60% 40% at 50% -10%,
+            var(--glow-1),
+            transparent 60%
+        ),
+        radial-gradient(
+            ellipse 50% 30% at 100% 10%,
+            var(--glow-2),
+            transparent 60%
+        );
+    background-size:
+        24px 24px,
+        100% 100%,
+        100% 100%;
+    background-attachment: fixed;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
 }
 
-/* --- Links --- */
+::selection {
+    background: var(--brand-soft);
+    color: var(--fg);
+}
+
+/* Scrollbars */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: var(--line-strong);
+    border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: var(--fg-mute);
+}
+
 a {
-    color: var(--primary);
+    color: var(--brand);
     text-decoration: none;
-    transition: color var(--transition-fast);
+    transition: color var(--t-fast);
 }
 a:hover {
-    color: var(--primary-hover);
+    color: var(--brand-hover);
 }
 
 /* =============================================================================
-   Header — fixed glassmorphism
+   Header
    ============================================================================= */
 .site-header {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    inset: 0 0 auto 0;
     height: var(--header-h);
     background: var(--header-bg);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--border-color);
+    backdrop-filter: blur(16px) saturate(180%);
+    -webkit-backdrop-filter: blur(16px) saturate(180%);
+    border-bottom: 1px solid var(--line);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 1.5rem;
+    padding: 0 1.25rem;
     z-index: 1000;
 }
+
 
 .header-left {
     display: flex;
@@ -134,15 +215,16 @@ a:hover {
 .header-logo {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    text-decoration: none;
+    gap: 0.55rem;
+    font-family: var(--font-mono);
     font-weight: 700;
-    font-size: 1.1rem;
-    color: var(--text-primary);
+    font-size: 0.95rem;
+    color: var(--fg);
+    letter-spacing: -0.01em;
 }
 
 .header-logo img {
-    height: 50px;
+    height: 28px;
     width: auto;
 }
 
@@ -166,54 +248,73 @@ a:hover {
 }
 
 .header-nav a {
-    color: var(--text-secondary);
-    font-size: 0.875rem;
+    position: relative;
+    color: var(--fg-soft);
+    font-size: 0.82rem;
     font-weight: 500;
-    padding: 0.4rem 0.75rem;
+    padding: 0.45rem 0.7rem;
     border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
+    transition: color var(--t-fast);
+}
+
+.header-nav a::before {
+    content: "";
+    position: absolute;
+    left: 0.7rem;
+    right: 0.7rem;
+    bottom: 0.25rem;
+    height: 1px;
+    background: var(--brand);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--t-fast);
 }
 
 .header-nav a:hover {
-    color: var(--text-primary);
-    background: var(--primary-subtle);
+    color: var(--fg);
+}
+.header-nav a:hover::before {
+    transform: scaleX(1);
 }
 
 .header-right {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.6rem;
 }
 
 .version-badge {
-    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
     font-weight: 600;
-    padding: 0.2rem 0.6rem;
-    border-radius: 999px;
-    background: var(--primary-subtle);
-    color: var(--primary);
-    border: 1px solid var(--primary-border);
+    padding: 0.22rem 0.55rem;
+    border-radius: var(--radius-sm);
+    background: var(--brand-soft);
+    color: var(--brand);
+    border: 1px solid var(--brand-line);
+    letter-spacing: 0.02em;
 }
 
-.theme-toggle {
-    background: none;
-    border: 1px solid var(--border-color);
+.theme-toggle,
+.mobile-menu-btn {
+    background: var(--bg-surface);
+    border: 1px solid var(--line);
     border-radius: var(--radius-sm);
     padding: 0.4rem;
     cursor: pointer;
-    color: var(--text-secondary);
+    color: var(--fg-soft);
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
-    transition: all var(--transition-fast);
+    width: 34px;
+    height: 34px;
+    transition: all var(--t-fast);
 }
 
 .theme-toggle:hover {
-    color: var(--primary);
-    border-color: var(--primary-border);
-    background: var(--primary-subtle);
+    color: var(--brand);
+    border-color: var(--brand-line);
+    background: var(--brand-soft);
 }
 
 .theme-toggle .icon-sun {
@@ -231,20 +332,10 @@ a:hover {
 
 .mobile-menu-btn {
     display: none;
-    background: none;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    padding: 0.4rem;
-    cursor: pointer;
-    color: var(--text-secondary);
-    width: 36px;
-    height: 36px;
-    align-items: center;
-    justify-content: center;
 }
 
 /* =============================================================================
-   Layout Container
+   Layout
    ============================================================================= */
 .docs-layout {
     display: flex;
@@ -253,7 +344,7 @@ a:hover {
 }
 
 /* =============================================================================
-   Sidebar — fixed left
+   Sidebar
    ============================================================================= */
 .docs-sidebar {
     position: fixed;
@@ -262,73 +353,105 @@ a:hover {
     width: var(--sidebar-w);
     height: calc(100vh - var(--header-h));
     background: var(--sidebar-bg);
-    border-right: 1px solid var(--border-color);
-    padding: 1.25rem 0.75rem;
+    border-right: 1px solid var(--line);
+    padding: 1.5rem 0.85rem 3rem;
     overflow-y: auto;
-    overflow-x: hidden;
     z-index: 100;
 }
 
 .docs-sidebar::-webkit-scrollbar {
     width: 4px;
 }
-.docs-sidebar::-webkit-scrollbar-track {
-    background: transparent;
-}
 .docs-sidebar::-webkit-scrollbar-thumb {
-    background: var(--border-color);
-    border-radius: 2px;
+    background: var(--line-strong);
 }
 
 .sidebar-section {
-    margin-bottom: 1.25rem;
+    position: relative;
+    margin-bottom: 1.5rem;
+    padding-left: 0.5rem;
 }
 
 .sidebar-title {
-    font-size: 0.7rem;
-    font-weight: 600;
+    position: relative;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--text-muted);
-    padding: 0.25rem 0.75rem;
-    margin-bottom: 0.25rem;
+    letter-spacing: 0.14em;
+    color: var(--fg-mute);
+    padding: 0.25rem 0.5rem 0.4rem 1.2rem;
+    margin-bottom: 0.35rem;
+}
+
+.sidebar-title::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 6px;
+    height: 6px;
+    border-radius: 1px;
+    background: var(--fg-mute);
+    box-shadow: 0 0 0 2px var(--sidebar-bg);
+}
+
+.sidebar-section .sidebar-title::before {
+    background: var(--brand);
+    box-shadow: 0 0 10px var(--brand-soft);
 }
 
 .sidebar-links {
     list-style: none;
+    border-left: 1px dashed var(--line-strong);
+    margin-left: 0.5rem;
 }
+
 .sidebar-links li {
     margin-bottom: 1px;
 }
 
 .sidebar-links a {
     display: block;
-    padding: 0.35rem 0.75rem;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    border-radius: var(--radius-sm);
-    transition: all var(--transition-fast);
-    border-left: 2px solid transparent;
+    padding: 0.32rem 0.75rem;
+    margin-left: -1px;
+    font-size: 0.84rem;
+    color: var(--fg-soft);
+    border-left: 1px solid transparent;
+    transition: all var(--t-fast);
 }
 
 .sidebar-links a:hover {
-    color: var(--text-primary);
-    background: var(--primary-subtle);
+    color: var(--fg);
+    border-left-color: var(--fg-mute);
 }
 
 .sidebar-links a.active {
-    color: var(--primary);
-    background: var(--primary-subtle);
-    border-left-color: var(--primary);
-    font-weight: 500;
+    color: var(--brand);
+    border-left-color: var(--brand);
+    font-weight: 600;
 }
 
 .sidebar-sublinks {
     list-style: none;
-    padding-left: 0.75rem;
+    padding-left: 0.65rem;
+    margin-top: 1px;
 }
 .sidebar-sublinks a {
-    font-size: 0.8rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    padding-left: 1rem;
+    position: relative;
+}
+.sidebar-sublinks a::before {
+    content: "·";
+    position: absolute;
+    left: 0.35rem;
+    color: var(--fg-mute);
+}
+.sidebar-sublinks a.active::before {
+    color: var(--brand);
 }
 
 /* =============================================================================
@@ -337,54 +460,124 @@ a:hover {
 .docs-main {
     flex: 1;
     margin-left: var(--sidebar-w);
-    padding: 2rem 3rem 4rem;
-    max-width: calc(var(--content-max-w) + var(--sidebar-w) + 6rem);
+    padding: 3rem 3.5rem 5rem;
+    max-width: calc(var(--content-max) + var(--sidebar-w) + 7rem);
     min-height: calc(100vh - var(--header-h));
 }
 
 .docs-content {
-    max-width: var(--content-max-w);
+    max-width: var(--content-max);
 }
 
 /* =============================================================================
    Typography
    ============================================================================= */
+.page-eyebrow {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--fg-mute);
+    margin-bottom: 0.75rem;
+    padding: 0.2rem 0.55rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 999px;
+    background: var(--bg-surface);
+}
+
+.page-eyebrow .sep {
+    color: var(--fg-mute);
+    margin: 0 0.25rem;
+    opacity: 0.6;
+}
+
 .docs-content h1 {
-    font-size: 2rem;
+    font-size: 2.1rem;
     font-weight: 700;
-    margin: 0 0 1.5rem 0;
-    letter-spacing: -0.02em;
-    line-height: 1.2;
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.025em;
+    line-height: 1.15;
+    position: relative;
+}
+
+.docs-content h1::after {
+    content: "";
+    display: block;
+    margin-top: 0.85rem;
+    margin-bottom: 1.75rem;
+    width: 48px;
+    height: 3px;
+    background: var(--brand);
+    border-radius: 2px;
 }
 
 .docs-content h2 {
-    font-size: 1.4rem;
-    font-weight: 600;
-    margin: 2.5rem 0 1rem 0;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--border-color);
-    letter-spacing: -0.01em;
+    position: relative;
+    font-size: 1.45rem;
+    font-weight: 700;
+    margin: 2.75rem 0 1rem;
+    padding-left: 0.85rem;
+    letter-spacing: -0.015em;
+}
+
+.docs-content h2::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.35em;
+    bottom: 0.35em;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--brand);
 }
 
 .docs-content h3 {
-    font-size: 1.15rem;
+    font-family: var(--font-mono);
+    font-size: 1.05rem;
     font-weight: 600;
-    margin: 2rem 0 0.75rem 0;
+    margin: 2rem 0 0.75rem;
+    color: var(--fg);
+    letter-spacing: -0.005em;
+}
+
+.docs-content h3::before {
+    content: "# ";
+    color: var(--brand);
+    font-weight: 500;
+    opacity: 0.7;
 }
 
 .docs-content h4 {
-    font-size: 1rem;
+    font-size: 0.95rem;
     font-weight: 600;
-    margin: 1.5rem 0 0.5rem 0;
+    margin: 1.5rem 0 0.5rem;
+    color: var(--fg-soft);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
 .docs-content p {
     margin-bottom: 1rem;
+    color: var(--fg);
+}
+
+.docs-content a:not(.btn) {
+    color: var(--brand);
+    background-image: linear-gradient(var(--brand-line), var(--brand-line));
+    background-size: 100% 1px;
+    background-repeat: no-repeat;
+    background-position: 0 100%;
+    transition: background-size var(--t-fast);
+}
+.docs-content a:not(.btn):hover {
+    background-image: linear-gradient(var(--brand), var(--brand));
 }
 
 .docs-content ul,
 .docs-content ol {
-    margin-bottom: 1rem;
+    margin: 0 0 1rem 0;
     padding-left: 1.5rem;
 }
 
@@ -392,80 +585,120 @@ a:hover {
     margin-bottom: 0.35rem;
 }
 
+.docs-content ul li::marker {
+    color: var(--brand);
+}
+
 .docs-content strong {
     font-weight: 600;
+    color: var(--fg);
 }
 
 .docs-content hr {
     border: none;
-    border-top: 1px solid var(--border-color);
-    margin: 2rem 0;
+    height: 1px;
+    margin: 2.5rem 0;
+    background: repeating-linear-gradient(
+        90deg,
+        var(--line-strong) 0 6px,
+        transparent 6px 12px
+    );
 }
 
 .docs-content blockquote {
-    border-left: 3px solid var(--primary);
-    padding: 0.5rem 1rem;
-    margin: 1rem 0;
-    color: var(--text-secondary);
-    background: var(--primary-subtle);
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    position: relative;
+    border-left: 2px solid var(--brand);
+    padding: 0.6rem 1rem 0.6rem 1.1rem;
+    margin: 1.25rem 0;
+    color: var(--fg-soft);
+    background: var(--brand-soft);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    font-style: italic;
 }
 
 /* --- Tables --- */
 .docs-content table {
     width: 100%;
     border-collapse: collapse;
-    margin: 1rem 0;
-    font-size: 0.9rem;
+    margin: 1.25rem 0;
+    font-size: 0.88rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    overflow: hidden;
 }
 
 .docs-content th,
 .docs-content td {
-    padding: 0.6rem 0.75rem;
+    padding: 0.65rem 0.85rem;
     text-align: left;
-    border: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--line);
+}
+
+.docs-content tr:last-child td {
+    border-bottom: none;
 }
 
 .docs-content th {
-    background: var(--bg-tertiary);
+    background: var(--bg-elev);
+    font-family: var(--font-mono);
     font-weight: 600;
-    font-size: 0.85rem;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-soft);
 }
 
-.docs-content tr:hover {
-    background: var(--bg-secondary);
+.docs-content tr:hover td {
+    background: var(--bg-surface);
 }
 
 /* --- Code --- */
 .docs-content code {
-    font-family:
-        "JetBrains Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+    font-family: var(--font-mono);
     font-size: 0.85em;
-    background: var(--bg-tertiary);
-    color: var(--primary-light);
-    padding: 0.15rem 0.4rem;
-    border-radius: 4px;
+    background: var(--bg-elev);
+    color: var(--brand);
+    padding: 0.12rem 0.4rem;
+    border-radius: 3px;
+    border: 1px solid var(--line);
 }
 
 [data-theme="light"] .docs-content code {
-    color: var(--primary-dark);
+    color: var(--brand);
+    background: var(--brand-soft);
+    border-color: transparent;
 }
 
 .docs-content pre {
+    position: relative;
     background: var(--bg-code);
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--line);
     border-radius: var(--radius-md);
-    padding: 1rem 1.25rem;
+    padding: 1.1rem 1.25rem;
     overflow-x: auto;
-    margin: 1rem 0;
-    line-height: 1.5;
+    margin: 1.25rem 0;
+    line-height: 1.55;
+    box-shadow: var(--shadow-card);
+}
+
+.docs-content pre::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--brand);
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+    opacity: 0.5;
 }
 
 .docs-content pre code {
-    background: none;
-    color: var(--text-primary);
+    background: transparent;
+    color: var(--fg);
     padding: 0;
-    font-size: 0.85rem;
+    border: none;
+    font-size: 0.84rem;
 }
 
 /* --- Images --- */
@@ -473,31 +706,53 @@ a:hover {
     max-width: 100%;
     height: auto;
     border-radius: var(--radius-md);
+    border: 1px solid var(--line);
 }
 
 /* =============================================================================
-   Section List (for section.html)
+   Section List
    ============================================================================= */
 ul.section-list {
     list-style: none;
     padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
 }
 
 ul.section-list li {
-    margin-bottom: 0.5rem;
-    padding: 0.6rem 1rem;
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
+    position: relative;
+    padding: 0.85rem 1rem 0.85rem 2.2rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--line);
     border-radius: var(--radius-md);
-    transition: all var(--transition-fast);
+    transition: all var(--t-fast);
+}
+
+ul.section-list li::before {
+    content: "›";
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--brand);
+    font-family: var(--font-mono);
+    font-weight: 700;
+    transition: transform var(--t-fast);
 }
 
 ul.section-list li:hover {
-    border-color: var(--primary-border);
-    background: var(--primary-subtle);
+    border-color: var(--brand-line);
+    background: var(--brand-soft);
+}
+
+ul.section-list li:hover::before {
+    transform: translate(3px, -50%);
 }
 
 ul.section-list li a {
+    background: none;
+    color: var(--fg);
     font-weight: 500;
 }
 
@@ -507,83 +762,121 @@ ul.section-list li a {
 nav.pagination {
     margin: 2rem 0;
 }
-
 nav.pagination .pagination-list {
     list-style: none;
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4rem;
     flex-wrap: wrap;
     align-items: center;
 }
-
 nav.pagination a {
+    font-family: var(--font-mono);
     display: inline-block;
-    padding: 0.3rem 0.6rem;
+    padding: 0.3rem 0.65rem;
     border-radius: var(--radius-sm);
-    border: 1px solid var(--border-color);
-    color: var(--text-secondary);
-    font-size: 0.875rem;
-    transition: all var(--transition-fast);
+    border: 1px solid var(--line);
+    color: var(--fg-soft);
+    font-size: 0.82rem;
+    background: var(--bg-surface);
+    transition: all var(--t-fast);
 }
-
 nav.pagination a:hover {
-    color: var(--primary);
-    border-color: var(--primary);
+    color: var(--brand);
+    border-color: var(--brand-line);
+    background: var(--brand-soft);
 }
-
 .pagination-current span {
     display: inline-block;
-    padding: 0.3rem 0.6rem;
+    padding: 0.3rem 0.65rem;
     border-radius: var(--radius-sm);
-    border: 1px solid var(--primary);
-    background: var(--primary-subtle);
-    color: var(--primary);
-    font-size: 0.875rem;
+    border: 1px solid var(--brand);
+    background: var(--brand-soft);
+    color: var(--brand);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
 }
 
 /* =============================================================================
-   Alert / Info Boxes
+   Alerts
    ============================================================================= */
 .alert {
-    padding: 0.75rem 1rem;
+    position: relative;
+    padding: 0.85rem 1rem 0.85rem 2.7rem;
     border-radius: var(--radius-md);
-    margin: 1rem 0;
-    border-left: 4px solid;
+    margin: 1.25rem 0;
+    border: 1px solid;
     font-size: 0.9rem;
+    background: var(--bg-surface);
+}
+
+.alert::before {
+    position: absolute;
+    left: 0.9rem;
+    top: 0.95rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-size: 0.78rem;
+}
+
+.alert strong {
+    display: inline-block;
+    margin-bottom: 0.2rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .alert-info,
 .alert[data-type="info"] {
-    background: rgba(34, 197, 94, 0.08);
-    border-color: var(--primary);
-    color: var(--text-primary);
+    border-color: var(--info);
+    background: rgba(96, 165, 250, 0.06);
+    color: var(--fg);
+}
+.alert-info::before,
+.alert[data-type="info"]::before {
+    content: "i";
+    color: var(--info);
+}
+
+.alert-tip,
+.alert[data-type="tip"] {
+    border-color: var(--seg-signature);
+    background: var(--seg-signature-soft);
+    color: var(--fg);
+}
+.alert-tip::before,
+.alert[data-type="tip"]::before {
+    content: "+";
+    color: var(--seg-signature);
 }
 
 .alert-warning,
 .alert[data-type="warning"] {
-    background: rgba(234, 179, 8, 0.08);
-    border-color: #eab308;
-    color: var(--text-primary);
+    border-color: var(--warn);
+    background: rgba(250, 204, 21, 0.07);
+    color: var(--fg);
+}
+.alert-warning::before,
+.alert[data-type="warning"]::before {
+    content: "!";
+    color: var(--warn);
 }
 
 .alert-error,
 .alert[data-type="error"],
 .alert[data-type="danger"] {
-    background: rgba(239, 68, 68, 0.08);
-    border-color: #ef4444;
-    color: var(--text-primary);
+    border-color: var(--danger);
+    background: rgba(248, 113, 113, 0.07);
+    color: var(--fg);
 }
-
-.alert-tip,
-.alert[data-type="tip"] {
-    background: rgba(59, 130, 246, 0.08);
-    border-color: #3b82f6;
-    color: var(--text-primary);
-}
-
-.alert strong {
-    display: block;
-    margin-bottom: 0.25rem;
+.alert-error::before,
+.alert[data-type="error"]::before,
+.alert[data-type="danger"]::before {
+    content: "×";
+    color: var(--danger);
+    font-size: 1rem;
+    top: 0.85rem;
 }
 
 /* =============================================================================
@@ -592,169 +885,332 @@ nav.pagination a:hover {
 .btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.6rem 1.25rem;
+    gap: 0.45rem;
+    padding: 0.62rem 1.1rem;
     border-radius: var(--radius-md);
-    font-size: 0.9rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
     font-weight: 600;
     cursor: pointer;
-    transition: all var(--transition-fast);
+    transition: all var(--t-fast);
     text-decoration: none;
-    border: none;
+    border: 1px solid transparent;
+    letter-spacing: -0.005em;
+    background-image: none !important;
 }
 
 .btn-primary {
-    background: var(--primary);
-    color: #fff;
+    background: var(--brand);
+    color: #04140b;
+    border-color: var(--brand);
+    box-shadow: 0 0 0 0 var(--brand-glow);
 }
 
 .btn-primary:hover {
-    background: var(--primary-hover);
-    color: #fff;
-    box-shadow: 0 0 20px rgba(34, 197, 94, 0.3);
+    background: var(--brand-hover);
+    color: #04140b;
+    box-shadow: 0 0 0 4px var(--brand-soft);
+    transform: translateY(-1px);
 }
 
 .btn-secondary {
-    background: transparent;
-    color: var(--text-primary);
-    border: 1px solid var(--border-color);
+    background: var(--bg-surface);
+    color: var(--fg);
+    border-color: var(--line-strong);
 }
 
 .btn-secondary:hover {
-    border-color: var(--primary);
-    color: var(--primary);
-    background: var(--primary-subtle);
+    border-color: var(--brand-line);
+    color: var(--brand);
+    background: var(--brand-soft);
 }
 
 /* =============================================================================
-   Landing Page — Hero
+   Landing — Hero
    ============================================================================= */
 .landing-hero {
     position: relative;
-    text-align: center;
-    padding: 5rem 2rem 4rem;
-    background: radial-gradient(
-        ellipse at 50% 0%,
-        rgba(34, 197, 94, 0.12) 0%,
-        transparent 60%
-    );
-    border-bottom: 1px solid var(--border-color);
+    padding: 5.5rem 2rem 4rem;
+    border-bottom: 1px solid var(--line);
+    overflow: hidden;
 }
 
-.landing-hero .hero-badge {
-    display: inline-block;
-    font-size: 0.8rem;
-    font-weight: 600;
-    padding: 0.3rem 0.9rem;
+.landing-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+        ellipse 55% 45% at 50% 0%,
+        var(--brand-soft) 0%,
+        transparent 65%
+    );
+    pointer-events: none;
+    z-index: 0;
+}
+
+.hero-inner {
+    position: relative;
+    z-index: 1;
+    max-width: 1080px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.hero-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--fg-soft);
+    background: var(--bg-surface);
+    border: 1px solid var(--line);
+    padding: 0.32rem 0.5rem 0.32rem 0.8rem;
     border-radius: 999px;
-    background: var(--primary-subtle);
-    color: var(--primary);
-    border: 1px solid var(--primary-border);
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.75rem;
+}
+
+.hero-meta .meta-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--brand);
+    box-shadow: 0 0 8px var(--brand-glow);
+    animation: pulse 2.4s ease-in-out infinite;
+}
+
+.hero-meta .meta-sep {
+    color: var(--fg-mute);
+}
+
+.hero-meta .meta-badge {
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    background: var(--brand-soft);
+    color: var(--brand);
+    border: 1px solid var(--brand-line);
+    font-weight: 600;
+}
+
+@keyframes pulse {
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.6;
+        transform: scale(0.85);
+    }
 }
 
 .landing-hero h1 {
-    font-size: clamp(2.2rem, 5vw, 3.5rem);
+    font-size: clamp(2.4rem, 5.5vw, 4rem);
     font-weight: 800;
-    letter-spacing: -0.03em;
-    line-height: 1.1;
-    margin-bottom: 1rem;
+    letter-spacing: -0.035em;
+    line-height: 1.05;
+    margin-bottom: 1.25rem;
+}
+
+.landing-hero h1 .seg-h,
+.landing-hero h1 .seg-p,
+.landing-hero h1 .seg-s {
+    color: var(--fg);
+}
+.landing-hero h1 .dot {
+    color: var(--fg-mute);
+    font-weight: 400;
+    margin: 0 0.05em;
 }
 
 .landing-hero h1 .highlight {
-    background: linear-gradient(135deg, var(--primary), var(--primary-light));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--brand);
 }
 
 .landing-hero .hero-desc {
-    font-size: 1.15rem;
-    color: var(--text-secondary);
-    max-width: 600px;
+    font-size: 1.1rem;
+    color: var(--fg-soft);
+    max-width: 620px;
     margin: 0 auto 2rem;
     line-height: 1.6;
 }
 
 .hero-buttons {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65rem;
     justify-content: center;
     flex-wrap: wrap;
-    margin-bottom: 3rem;
+    margin-bottom: 3.5rem;
 }
 
-/* --- Terminal Mockup --- */
-.terminal-mockup {
-    max-width: 600px;
+/* --- Token visualizer (replaces plain terminal) --- */
+.token-card {
+    max-width: 680px;
     margin: 0 auto;
-    background: #0d0d0d;
-    border: 1px solid var(--border-color);
+    background: var(--bg-surface);
+    border: 1px solid var(--line);
     border-radius: var(--radius-lg);
     overflow: hidden;
     text-align: left;
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--shadow-card);
+    position: relative;
 }
 
-[data-theme="light"] .terminal-mockup {
-    background: #1e1e1e;
-}
 
-.terminal-header {
+.token-head {
+    position: relative;
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 0.75rem 1rem;
-    background: #161616;
-    border-bottom: 1px solid #27272a;
+    justify-content: space-between;
+    padding: 0.65rem 0.95rem;
+    background: var(--bg-elev);
+    border-bottom: 1px solid var(--line);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--fg-mute);
 }
 
-[data-theme="light"] .terminal-header {
-    background: #2d2d2d;
-    border-bottom-color: #3d3d3d;
+.token-head .token-tag {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
 }
 
-.terminal-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
+.token-head .token-tag::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: 1px;
+    background: var(--brand);
+    box-shadow: 0 0 8px var(--brand-glow);
 }
 
-.terminal-dot.red {
-    background: #ff5f57;
-}
-.terminal-dot.yellow {
-    background: #febc2e;
-}
-.terminal-dot.green {
-    background: #28c840;
+.token-head .token-id {
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
 
-.terminal-body {
-    padding: 1rem 1.25rem;
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.85rem;
-    line-height: 1.6;
-    color: #e4e4e7;
+.token-body {
+    position: relative;
+    padding: 1rem 1.1rem 1.2rem;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.7;
 }
 
-.terminal-body .prompt {
-    color: var(--primary);
+.token-row {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: 0.75rem;
+    align-items: baseline;
+    padding: 0.25rem 0;
 }
-.terminal-body .cmd {
-    color: #fafafa;
+
+.token-row .tag {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    text-align: center;
 }
-.terminal-body .comment {
-    color: #71717a;
+
+.token-row .tag {
+    color: var(--fg-soft);
+    background: var(--bg-elev);
+    border: 1px solid var(--line-strong);
+}
+
+.token-row.h .tag {
+    color: var(--seg-header);
+    border-color: color-mix(in srgb, var(--seg-header) 40%, var(--line-strong));
+}
+.token-row.p .tag {
+    color: var(--seg-payload);
+    border-color: color-mix(in srgb, var(--seg-payload) 40%, var(--line-strong));
+}
+.token-row.s .tag {
+    color: var(--seg-signature);
+    border-color: color-mix(in srgb, var(--seg-signature) 40%, var(--line-strong));
+}
+
+.token-row .val {
+    color: var(--fg-soft);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.token-divider {
+    height: 1px;
+    background: repeating-linear-gradient(
+        90deg,
+        var(--line-strong) 0 4px,
+        transparent 4px 8px
+    );
+    margin: 0.4rem 0;
+}
+
+.token-foot {
+    display: flex;
+    gap: 0.65rem;
+    padding: 0.7rem 1.1rem;
+    border-top: 1px solid var(--line);
+    background: var(--bg-elev);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--fg);
+}
+
+.token-foot .prompt {
+    color: var(--brand);
+    user-select: none;
+}
+
+.token-foot .blink {
+    width: 7px;
+    height: 1.05em;
+    background: var(--brand);
+    display: inline-block;
+    vertical-align: -0.15em;
+    animation: blink 1.05s steps(1) infinite;
+}
+
+@keyframes blink {
+    50% {
+        opacity: 0;
+    }
 }
 
 /* =============================================================================
-   Landing Page — Features
+   Landing — Features
    ============================================================================= */
 .landing-features {
-    padding: 4rem 2rem;
+    padding: 5rem 2rem 4rem;
     max-width: 1100px;
     margin: 0 auto;
+}
+
+.section-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    justify-content: center;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--fg-mute);
+    margin-bottom: 1rem;
+}
+
+.section-eyebrow::before,
+.section-eyebrow::after {
+    content: "";
+    width: 28px;
+    height: 1px;
+    background: var(--line-strong);
 }
 
 .landing-features .section-header {
@@ -763,116 +1219,196 @@ nav.pagination a:hover {
 }
 
 .landing-features .section-header h2 {
-    font-size: 1.75rem;
+    font-size: clamp(1.5rem, 3vw, 2rem);
     font-weight: 700;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.6rem;
     border: none;
     padding: 0;
+    letter-spacing: -0.02em;
+}
+.landing-features .section-header h2::before {
+    content: none;
 }
 
 .landing-features .section-header p {
-    color: var(--text-secondary);
-    max-width: 550px;
+    color: var(--fg-soft);
+    max-width: 560px;
     margin: 0 auto;
 }
 
 .features-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 1.25rem;
+    gap: 1rem;
 }
 
 .feature-card {
-    background: var(--bg-card);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    padding: 1.5rem;
-    transition: all var(--transition-normal);
+    position: relative;
+    background: var(--bg-surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    padding: 1.6rem 1.4rem 1.4rem;
+    transition: all var(--t-mid);
+    overflow: hidden;
+}
+
+/* Corner brackets */
+.feature-card::before,
+.feature-card::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border: 1px solid var(--fg-mute);
+    opacity: 0.5;
+    transition: all var(--t-mid);
+}
+
+.feature-card::before {
+    top: 8px;
+    left: 8px;
+    border-right: none;
+    border-bottom: none;
+}
+
+.feature-card::after {
+    bottom: 8px;
+    right: 8px;
+    border-left: none;
+    border-top: none;
 }
 
 .feature-card:hover {
-    border-color: var(--primary-border);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
+    border-color: var(--brand-line);
+    transform: translateY(-3px);
+    box-shadow: 0 16px 32px -16px var(--brand-soft),
+        0 0 0 1px var(--brand-line);
+}
+
+.feature-card:hover::before,
+.feature-card:hover::after {
+    border-color: var(--brand);
+    opacity: 1;
+    width: 18px;
+    height: 18px;
+}
+
+.feature-card .feature-num {
+    position: absolute;
+    top: 0.85rem;
+    right: 1.1rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--fg-mute);
+    letter-spacing: 0.05em;
 }
 
 .feature-card .feature-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: var(--radius-md);
-    background: var(--primary-subtle);
-    color: var(--primary);
+    width: 38px;
+    height: 38px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-elev);
+    color: var(--brand);
+    border: 1px solid var(--line-strong);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.1rem;
     margin-bottom: 1rem;
+    position: relative;
+    z-index: 1;
 }
 
+
 .feature-card h3 {
-    font-size: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
     font-weight: 600;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.45rem;
+    letter-spacing: -0.005em;
+    color: var(--fg);
 }
 
 .feature-card p {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    line-height: 1.5;
+    font-size: 0.86rem;
+    color: var(--fg-soft);
+    line-height: 1.55;
+    margin: 0;
 }
 
 /* =============================================================================
-   Landing Page — CTA
+   Landing — CTA
    ============================================================================= */
 .landing-cta {
-    padding: 3rem 2rem;
+    position: relative;
+    padding: 4rem 2rem;
     text-align: center;
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--line);
+    overflow: hidden;
+}
+
+.landing-cta::before {
+    content: "";
+    position: absolute;
+    inset: 0;
     background: radial-gradient(
-        ellipse at 50% 100%,
-        rgba(34, 197, 94, 0.06) 0%,
+        ellipse 60% 80% at 50% 100%,
+        var(--brand-soft) 0%,
         transparent 60%
     );
+    pointer-events: none;
+}
+
+.landing-cta-inner {
+    position: relative;
+    max-width: 540px;
+    margin: 0 auto;
 }
 
 .landing-cta h2 {
-    font-size: 1.5rem;
+    font-size: 1.6rem;
     font-weight: 700;
     margin-bottom: 0.75rem;
     border: none;
     padding: 0;
+    letter-spacing: -0.02em;
+}
+
+.landing-cta h2::before {
+    content: none;
 }
 
 .landing-cta p {
-    color: var(--text-secondary);
-    max-width: 500px;
-    margin: 0 auto 1.5rem;
+    color: var(--fg-soft);
+    margin: 0 auto 1.75rem;
 }
 
 /* =============================================================================
    Footer
    ============================================================================= */
 .site-footer {
-    padding: 1.5rem 2rem;
-    border-top: 1px solid var(--border-color);
+    padding: 2rem 1.5rem 2.5rem;
+    border-top: 1px solid var(--line);
     text-align: center;
-    color: var(--text-muted);
-    font-size: 0.8rem;
+    color: var(--fg-mute);
+    font-size: 0.78rem;
+    background: var(--bg-sunken);
 }
 
 .site-footer a {
-    color: var(--text-secondary);
+    color: var(--fg-soft);
 }
+
 .site-footer a:hover {
-    color: var(--primary);
+    color: var(--brand);
 }
 
 .footer-content {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 1rem;
+    gap: 0.85rem;
     flex-wrap: wrap;
+    font-family: var(--font-mono);
 }
 
 .footer-content .separator {
@@ -880,124 +1416,130 @@ nav.pagination a:hover {
 }
 
 .footer-logo {
-    height: 24px;
-    opacity: 0.6;
-    transition: opacity var(--transition-fast);
+    height: 20px;
+    opacity: 0.55;
+    transition: opacity var(--t-fast);
 }
 .footer-logo:hover {
     opacity: 1;
 }
 
 /* =============================================================================
-   404 Page
+   404
    ============================================================================= */
 .error-page {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-height: 60vh;
+    min-height: 70vh;
     text-align: center;
-    padding: 2rem;
+    padding: 3rem 2rem;
+    font-family: var(--font-mono);
 }
 
 .error-page h1 {
-    font-size: 4rem;
+    font-size: 5rem;
     font-weight: 800;
-    color: var(--primary);
-    margin-bottom: 0.5rem;
+    color: var(--brand);
+    margin-bottom: 0.25rem;
+    letter-spacing: -0.04em;
 }
 
 .error-page p {
-    color: var(--text-secondary);
-    margin-bottom: 1.5rem;
+    color: var(--fg-soft);
+    margin-bottom: 1.75rem;
+    font-family: var(--font-sans);
 }
 
 /* =============================================================================
-   Responsive — Tablet (1024px)
+   Sidebar overlay (mobile)
+   ============================================================================= */
+.sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 499;
+}
+
+.sidebar-overlay.active {
+    display: block;
+}
+
+/* =============================================================================
+   Responsive — Tablet
    ============================================================================= */
 @media (max-width: 1024px) {
     .docs-sidebar {
         transform: translateX(-100%);
-        transition: transform var(--transition-normal);
+        transition: transform var(--t-mid);
         z-index: 500;
-        background: var(--bg-primary);
     }
-
     .docs-sidebar.open {
         transform: translateX(0);
-        box-shadow: var(--shadow-lg);
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
     }
-
     .docs-main {
         margin-left: 0;
         padding: 2rem 2rem 4rem;
         max-width: 100%;
     }
-
     .mobile-menu-btn {
         display: flex;
     }
-
     .features-grid {
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
 /* =============================================================================
-   Responsive — Mobile (768px)
+   Responsive — Mobile
    ============================================================================= */
 @media (max-width: 768px) {
     .site-header {
         padding: 0 1rem;
     }
-
     .header-nav {
         display: none;
     }
-
-    .docs-main {
-        padding: 1.5rem 1rem 3rem;
+    .header-logo img {
+        height: 24px;
     }
-
+    .docs-main {
+        padding: 1.75rem 1.1rem 3rem;
+    }
     .landing-hero {
-        padding: 3rem 1.5rem 2.5rem;
+        padding: 3.5rem 1.25rem 2.5rem;
     }
     .landing-hero h1 {
-        font-size: 2rem;
+        font-size: 2.1rem;
     }
-
+    .hero-desc {
+        font-size: 1rem;
+    }
+    .landing-features {
+        padding: 3rem 1.25rem;
+    }
     .features-grid {
         grid-template-columns: 1fr;
     }
-
     .docs-content h1 {
-        font-size: 1.6rem;
+        font-size: 1.7rem;
     }
     .docs-content h2 {
-        font-size: 1.25rem;
+        font-size: 1.2rem;
     }
-
     .docs-content pre {
-        padding: 0.75rem;
+        padding: 0.85rem;
         font-size: 0.8rem;
     }
-
     .docs-content table {
         display: block;
         overflow-x: auto;
     }
-}
-
-/* --- Sidebar overlay for mobile --- */
-.sidebar-overlay {
-    display: none;
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 499;
-}
-
-.sidebar-overlay.active {
-    display: block;
+    .token-row {
+        grid-template-columns: 72px 1fr;
+    }
 }

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -23,8 +23,6 @@
     --seg-header: #ff4d8d;     /* signed pink/red */
     --seg-payload: #b18bff;    /* violet */
     --seg-signature: #22d3ee;  /* cyan */
-    --seg-header-soft: rgba(255, 77, 141, 0.14);
-    --seg-payload-soft: rgba(177, 139, 255, 0.14);
     --seg-signature-soft: rgba(34, 211, 238, 0.14);
 
     /* Status */
@@ -90,8 +88,6 @@
     --seg-header: #e23170;
     --seg-payload: #7c5cff;
     --seg-signature: #0aa7c6;
-    --seg-header-soft: rgba(226, 49, 112, 0.1);
-    --seg-payload-soft: rgba(124, 92, 255, 0.1);
     --seg-signature-soft: rgba(10, 167, 198, 0.1);
 
     --shadow-card: 0 1px 0 rgba(255, 255, 255, 0.6) inset,
@@ -1124,15 +1120,15 @@ nav.pagination a:hover {
 
 .token-row.h .tag {
     color: var(--seg-header);
-    border-color: color-mix(in srgb, var(--seg-header) 40%, var(--line-strong));
+    border-color: var(--seg-header);
 }
 .token-row.p .tag {
     color: var(--seg-payload);
-    border-color: color-mix(in srgb, var(--seg-payload) 40%, var(--line-strong));
+    border-color: var(--seg-payload);
 }
 .token-row.s .tag {
     color: var(--seg-signature);
-    border-color: color-mix(in srgb, var(--seg-signature) 40%, var(--line-strong));
+    border-color: var(--seg-signature);
 }
 
 .token-row .val {
@@ -1541,5 +1537,23 @@ nav.pagination a:hover {
     }
     .token-row {
         grid-template-columns: 72px 1fr;
+    }
+}
+
+/* =============================================================================
+   Reduced motion
+   ============================================================================= */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+    }
+    .hero-meta .meta-dot,
+    .token-foot .blink {
+        animation: none;
     }
 }

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -23,10 +23,10 @@
       <div class="hero-buttons">
         <a href="/get_started/installation/" class="btn btn-primary">
           Get Started
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+          <svg aria-hidden="true" focusable="false" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
         </a>
         <a href="https://github.com/hahwul/jwt-hack" class="btn btn-secondary" target="_blank" rel="noopener">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.18-.02-2.13-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.21-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.75.12 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.79.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+          <svg aria-hidden="true" focusable="false" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.18-.02-2.13-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.21-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.75.12 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.79.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
           GitHub
         </a>
       </div>
@@ -72,7 +72,7 @@
       <div class="feature-card">
         <span class="feature-num">01</span>
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          <svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
         </div>
         <h3>encode &amp; decode</h3>
         <p>JWT and JWE tokens with multiple algorithms, custom headers, and DEFLATE compression.</p>
@@ -80,7 +80,7 @@
       <div class="feature-card">
         <span class="feature-num">02</span>
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          <svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
         </div>
         <h3>verify signatures</h3>
         <p>Symmetric and asymmetric algorithms verified with secrets or keys, plus expiration validation.</p>
@@ -88,7 +88,7 @@
       <div class="feature-card">
         <span class="feature-num">03</span>
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+          <svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
         </div>
         <h3>advanced cracking</h3>
         <p>Crack JWT secrets via dictionary or brute-force, with support for compressed tokens.</p>
@@ -96,7 +96,7 @@
       <div class="feature-card">
         <span class="feature-num">04</span>
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
+          <svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
         </div>
         <h3>attack payloads</h3>
         <p>Generate none-alg, algorithm confusion, and header manipulation attack variants.</p>
@@ -104,7 +104,7 @@
       <div class="feature-card">
         <span class="feature-num">05</span>
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+          <svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
         </div>
         <h3>high performance</h3>
         <p>Built in Rust with parallel processing for intensive operations &mdash; raw speed under load.</p>
@@ -112,7 +112,7 @@
       <div class="feature-card">
         <span class="feature-num">06</span>
         <div class="feature-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>
+          <svg aria-hidden="true" focusable="false" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>
         </div>
         <h3>mcp server</h3>
         <p>Integrate with AI models via Model Context Protocol for intelligent JWT analysis.</p>
@@ -128,7 +128,7 @@
       <p>{{ page.extra.cta_description }}</p>
       <a href="{{ page.extra.cta_button_url }}" class="btn btn-secondary" target="_blank" rel="noopener">
         {{ page.extra.cta_button_text }}
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><polyline points="7 7 17 7 17 17"/></svg>
+        <svg aria-hidden="true" focusable="false" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><polyline points="7 7 17 7 17 17"/></svg>
       </a>
     </div>
   </section>

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -4,92 +4,133 @@
 
 {% block body %}
 <main style="padding-top: var(--header-h);">
-  <!-- Hero Section -->
+  <!-- Hero -->
   <section class="landing-hero">
-    <div class="hero-badge">{{ page.extra.hero_badge }}</div>
-    <h1>{{ page.extra.hero_title }}</h1>
-    <p class="hero-desc">{{ page.extra.hero_description }}</p>
-    <div class="hero-buttons">
-      <a href="/get_started/installation/" class="btn btn-primary">Get Started</a>
-      <a href="https://github.com/hahwul/jwt-hack" class="btn btn-secondary" target="_blank" rel="noopener">View on GitHub</a>
-    </div>
-
-    <div class="terminal-mockup">
-      <div class="terminal-header">
-        <span class="terminal-dot red"></span>
-        <span class="terminal-dot yellow"></span>
-        <span class="terminal-dot green"></span>
+    <div class="hero-inner">
+      <div class="hero-meta">
+        <span class="meta-dot"></span>
+        <span>cryptography · security · toolkit</span>
+        <span class="meta-sep">·</span>
+        <span class="meta-badge">{{ page.extra.hero_badge }}</span>
       </div>
-      <div class="terminal-body">
-        <div><span class="prompt">$</span> <span class="cmd">jwt-hack decode eyJhbGciOiJIUzI1...</span></div>
-        <div><span class="comment"># Decode and analyze JWT tokens</span></div>
-        <br>
-        <div><span class="prompt">$</span> <span class="cmd">jwt-hack crack -w wordlist.txt &lt;TOKEN&gt;</span></div>
-        <div><span class="comment"># Crack JWT secrets with dictionary attacks</span></div>
-        <br>
-        <div><span class="prompt">$</span> <span class="cmd">jwt-hack scan &lt;TOKEN&gt;</span></div>
-        <div><span class="comment"># Scan for JWT vulnerabilities</span></div>
+
+      <h1>
+        <span class="seg-h">jwt</span><span class="dot">-</span><span class="highlight">hack</span>
+      </h1>
+
+      <p class="hero-desc">{{ page.extra.hero_description }}</p>
+
+      <div class="hero-buttons">
+        <a href="/get_started/installation/" class="btn btn-primary">
+          Get Started
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </a>
+        <a href="https://github.com/hahwul/jwt-hack" class="btn btn-secondary" target="_blank" rel="noopener">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.18-.02-2.13-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.89-.39.98 0 1.97.13 2.89.39 2.21-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.75.12 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.79.56C20.21 21.38 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>
+          GitHub
+        </a>
+      </div>
+
+      <!-- Token Visualizer -->
+      <div class="token-card">
+        <div class="token-head">
+          <span class="token-tag">token.preview</span>
+          <span class="token-id">HS256 · 3-segment</span>
+        </div>
+        <div class="token-body">
+          <div class="token-row h">
+            <span class="tag">header</span>
+            <span class="val">eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9</span>
+          </div>
+          <div class="token-row p">
+            <span class="tag">payload</span>
+            <span class="val">eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkhB...</span>
+          </div>
+          <div class="token-row s">
+            <span class="tag">sig</span>
+            <span class="val">SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQss...</span>
+          </div>
+          <div class="token-divider"></div>
+        </div>
+        <div class="token-foot">
+          <span class="prompt">$</span>
+          <span>jwt-hack decode &lt;token&gt;</span>
+          <span class="blink"></span>
+        </div>
       </div>
     </div>
   </section>
 
-  <!-- Features Section -->
+  <!-- Features -->
   <section class="landing-features">
     <div class="section-header">
+      <div class="section-eyebrow">capabilities</div>
       <h2>{{ page.extra.features_title }}</h2>
       <p>{{ page.extra.features_description }}</p>
     </div>
     <div class="features-grid">
       <div class="feature-card">
+        <span class="feature-num">01</span>
         <div class="feature-icon">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
         </div>
-        <h3>JWT/JWE Encoding & Decoding</h3>
-        <p>Encode and decode JWT and JWE tokens with support for multiple algorithms, custom headers, and DEFLATE compression.</p>
+        <h3>encode &amp; decode</h3>
+        <p>JWT and JWE tokens with multiple algorithms, custom headers, and DEFLATE compression.</p>
       </div>
       <div class="feature-card">
+        <span class="feature-num">02</span>
         <div class="feature-icon">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
         </div>
-        <h3>Signature Verification</h3>
-        <p>Verify JWT signatures using secrets or keys for symmetric and asymmetric algorithms with expiration validation.</p>
+        <h3>verify signatures</h3>
+        <p>Symmetric and asymmetric algorithms verified with secrets or keys, plus expiration validation.</p>
       </div>
       <div class="feature-card">
+        <span class="feature-num">03</span>
         <div class="feature-icon">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
         </div>
-        <h3>Advanced Cracking</h3>
-        <p>Crack JWT secrets using dictionary attacks or brute force methods with support for compressed tokens.</p>
+        <h3>advanced cracking</h3>
+        <p>Crack JWT secrets via dictionary or brute-force, with support for compressed tokens.</p>
       </div>
       <div class="feature-card">
+        <span class="feature-num">04</span>
         <div class="feature-icon">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
         </div>
-        <h3>Attack Payload Generation</h3>
-        <p>Generate various JWT attack payloads including none algorithm, algorithm confusion, and header manipulation attacks.</p>
+        <h3>attack payloads</h3>
+        <p>Generate none-alg, algorithm confusion, and header manipulation attack variants.</p>
       </div>
       <div class="feature-card">
+        <span class="feature-num">05</span>
         <div class="feature-icon">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
         </div>
-        <h3>High Performance</h3>
-        <p>Built with Rust for maximum speed and efficiency, leveraging parallel processing for intensive operations.</p>
+        <h3>high performance</h3>
+        <p>Built in Rust with parallel processing for intensive operations &mdash; raw speed under load.</p>
       </div>
       <div class="feature-card">
+        <span class="feature-num">06</span>
         <div class="feature-icon">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>
         </div>
-        <h3>MCP Server Support</h3>
-        <p>Integrates with AI models via Model Context Protocol for intelligent JWT analysis and testing.</p>
+        <h3>mcp server</h3>
+        <p>Integrate with AI models via Model Context Protocol for intelligent JWT analysis.</p>
       </div>
     </div>
   </section>
 
-  <!-- CTA Section -->
+  <!-- CTA -->
   <section class="landing-cta">
-    <h2>{{ page.extra.cta_title }}</h2>
-    <p>{{ page.extra.cta_description }}</p>
-    <a href="{{ page.extra.cta_button_url }}" class="btn btn-secondary" target="_blank" rel="noopener">{{ page.extra.cta_button_text }}</a>
+    <div class="landing-cta-inner">
+      <div class="section-eyebrow">open source</div>
+      <h2>{{ page.extra.cta_title }}</h2>
+      <p>{{ page.extra.cta_description }}</p>
+      <a href="{{ page.extra.cta_button_url }}" class="btn btn-secondary" target="_blank" rel="noopener">
+        {{ page.extra.cta_button_text }}
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><polyline points="7 7 17 7 17 17"/></svg>
+      </a>
+    </div>
   </section>
 </main>
 {% endblock %}

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -6,7 +6,7 @@
   <main class="docs-main">
     <div class="docs-content">
       {% if page.section %}
-      <div class="page-eyebrow">{{ page.section }}</div>
+      <div class="page-eyebrow">{{ page.section | replace("_", " ") | title }}</div>
       {% endif %}
       <h1>{{ page.title }}</h1>
       {{ content }}

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -5,6 +5,9 @@
   {% include "sidebar.html" %}
   <main class="docs-main">
     <div class="docs-content">
+      {% if page.section %}
+      <div class="page-eyebrow">{{ page.section }}</div>
+      {% endif %}
       <h1>{{ page.title }}</h1>
       {{ content }}
     </div>


### PR DESCRIPTION
## Summary

Refresh the documentation site with a distinctive, modern look unique to jwt-hack — inspired by the noir docs structure but with its own identity.

- **Brand-green accent** on a deep midnight surface with a subtle dotted-grid backdrop
- **Monospace editorial typography** — `h3` carries a `#` prefix, `h1` gets a brand-green underline mark, section eyebrows on doc pages
- **Corner-bracket feature cards** with numbered indices (`01`–`06`) and unified iconography
- **Token-preview visualizer** replacing the plain terminal mockup on the landing page — the only place segment colors appear (header / payload / sig labels), since they semantically mirror JWT structure
- **Refined sidebar** with dashed-tree link rails, brand-green section dots, and monospace sub-links prefixed by `·`
- **No multi-stop gradients** — every accent is a single solid color
- Cleaner alerts, tables, code blocks, pagination, and 404 page

## Test plan

- [ ] `cd docs && hwaro serve` and inspect `/`, `/get_started/introduction/`, `/usage/commands/`, `/support/faq/`
- [ ] Toggle dark / light theme via the header button
- [ ] Verify responsive layout at 1024px and 768px breakpoints
- [ ] Check sidebar active-link highlighting
- [ ] Confirm alerts, tables, and code blocks render correctly on a content-heavy page