### PR TITLE
fix: correct JWT/JWE security defects and scan false-negatives

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -452,14 +452,17 @@ fn collect_attack_payloads(token: &str, results: &[VulnerabilityResult]) -> Resu
 
 /// Check for none algorithm vulnerability
 fn check_none_algorithm(_token: &str, decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
-    let alg_str = format!("{:?}", decoded.algorithm).to_lowercase();
-    let vulnerable = alg_str.contains("none")
-        || decoded
-            .header
-            .get("alg")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_lowercase() == "none")
-            .unwrap_or(false);
+    // `decoded.algorithm` is a `jsonwebtoken::Algorithm`, which has no `none`
+    // variant (the decoder maps `none` to an HS256 sentinel), so the only
+    // reliable source is the raw header. Match a plain string `alg: "none"` as
+    // well as the array form `alg: ["none", ...]`, a parser-confusion variant
+    // some libraries resolve to the first element.
+    let is_none_str =
+        |v: &serde_json::Value| v.as_str().is_some_and(|s| s.eq_ignore_ascii_case("none"));
+    let vulnerable = decoded.header.get("alg").is_some_and(|alg| match alg {
+        serde_json::Value::Array(items) => items.iter().any(is_none_str),
+        other => is_none_str(other),
+    });
 
     let result = if vulnerable {
         VulnerabilityResult {
@@ -1178,7 +1181,15 @@ fn check_psychic_signature(
 ) -> Result<VulnerabilityResult> {
     use base64::Engine;
     let name = "Psychic Signature".to_string();
-    let alg_str = format!("{:?}", decoded.algorithm).to_uppercase();
+    // Read `alg` from the raw header so this still fires on tokens that fail
+    // strict decode (where `decoded.algorithm` is only an HS256 sentinel) and on
+    // curves jwt-hack's decoder doesn't model (e.g. ES512 / CVE-2022-21449 on P-521).
+    let alg_str = decoded
+        .header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .map(str::to_uppercase)
+        .unwrap_or_else(|| format!("{:?}", decoded.algorithm).to_uppercase());
     if !alg_str.starts_with("ES") {
         return Ok(VulnerabilityResult {
             name,
@@ -1850,6 +1861,43 @@ mod tests {
         let decoded = jwt::decode(&token).unwrap();
         let r = check_psychic_signature(&token, &decoded).unwrap();
         assert!(!r.vulnerable);
+    }
+
+    #[test]
+    fn test_check_psychic_signature_detects_es512_on_fallback_path() {
+        // ES512 (P-521) tokens can fail strict decode, leaving only an HS256
+        // sentinel in `decoded.algorithm`. The check must still read `alg` from
+        // the header so CVE-2022-21449 is caught on the header-only fallback path.
+        use base64::Engine;
+        let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"ES512","typ":"JWT"}"#.as_bytes());
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}".as_ref());
+        let sig_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([0u8; 132]);
+        let token = format!("{header_b64}.{claims_b64}.{sig_b64}");
+        // Synthetic decode with the HS256 sentinel, mirroring the fallback path.
+        let decoded = header_only_decoded(r#"{"alg":"ES512","typ":"JWT"}"#);
+        let r = check_psychic_signature(&token, &decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_check_none_algorithm_array_form() {
+        // `alg: ["none", "HS256"]` is a parser-confusion variant; some libraries
+        // resolve to the first element and accept an unsigned token. jwt::decode
+        // rejects array alg, so use a header-only DecodedToken.
+        let decoded = header_only_decoded(r#"{"alg":["none","HS256"],"typ":"JWT"}"#);
+        let r = check_none_algorithm("token", &decoded).unwrap();
+        assert!(r.vulnerable, "array containing 'none' should be flagged");
+        assert_eq!(r.name, "None Algorithm");
+        assert_eq!(r.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_check_none_algorithm_array_without_none_is_safe() {
+        let decoded = header_only_decoded(r#"{"alg":["HS256","RS256"],"typ":"JWT"}"#);
+        let r = check_none_algorithm("token", &decoded).unwrap();
+        assert!(!r.vulnerable, "array without 'none' must not be flagged");
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -318,21 +318,8 @@ fn encode_compressed_jwt(
                 sig
             }
             Algorithm::HS384 | Algorithm::HS512 => {
-                // For HS384/HS512, we need to use the jsonwebtoken library
-                // Create a temporary uncompressed token for signing
-                let temp_header = jsonwebtoken::Header::new(algorithm);
-                let temp_claims = serde_json::json!({"temp": "data"});
-                let encoding_key = EncodingKey::from_secret(secret.as_bytes());
-                let temp_token = jsonwebtoken::encode(&temp_header, &temp_claims, &encoding_key)?;
-
-                // Extract signature from temp token and apply to our message
-                let temp_parts: Vec<&str> = temp_token.split('.').collect();
-                if temp_parts.len() != 3 {
-                    return Err(anyhow!("Failed to create temporary token for signing"));
-                }
-
-                // We need to manually sign the compressed message
-                // This is complex for HS384/HS512, so let's use a different approach
+                // Signing a compressed payload with HS384/HS512 would require manually
+                // computing the MAC over the compressed segment; not yet implemented.
                 return Err(anyhow!("HS384/HS512 with compression not yet supported"));
             }
             _ => return Err(anyhow!("HMAC algorithms require a secret key")),
@@ -677,11 +664,13 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
                     }
                 }
                 Algorithm::HS384 | Algorithm::HS512 => {
-                    // For HS384 and HS512, use jsonwebtoken directly which handles signature and time validation
+                    // For HS384 and HS512, use jsonwebtoken directly which handles signature and time validation.
+                    // Route through handle_verification_result so expired/not-yet-valid tokens surface as
+                    // distinct errors instead of collapsing into a plain `false`, matching the HS256/RSA/EC paths.
                     let decoding_key = DecodingKey::from_secret(secret.as_bytes());
                     let validation = create_validation(decoded_token.algorithm, options);
                     let result = jsonwebtoken::decode::<Value>(token, &decoding_key, &validation);
-                    Ok(result.is_ok())
+                    handle_verification_result(result)
                 }
                 _ => Err(anyhow!(
                     "Secret key provided but token uses algorithm {:?}. Secret keys can only verify HMAC algorithms (HS256, HS384, HS512)",
@@ -803,6 +792,14 @@ pub fn decrypt_jwe(token: &str, key: &str) -> Result<String> {
                     key_bytes.len()
                 ));
             }
+            // AES-GCM requires a 96-bit (12-byte) nonce; converting a slice of any
+            // other length into `Nonce` panics, so reject malformed IVs up front.
+            if iv_bytes.len() != 12 {
+                return Err(anyhow!(
+                    "Invalid IV length: AES-GCM requires a 12-byte nonce, got {}",
+                    iv_bytes.len()
+                ));
+            }
             let mut key_128: [u8; 16] = key_bytes
                 .try_into()
                 .map_err(|_| anyhow!("Failed to convert key to 16-byte array"))?;
@@ -833,6 +830,14 @@ pub fn decrypt_jwe(token: &str, key: &str) -> Result<String> {
                 return Err(anyhow!(
                     "A256GCM requires a 32-byte key, got {}",
                     key_bytes.len()
+                ));
+            }
+            // AES-GCM requires a 96-bit (12-byte) nonce; converting a slice of any
+            // other length into `Nonce` panics, so reject malformed IVs up front.
+            if iv_bytes.len() != 12 {
+                return Err(anyhow!(
+                    "Invalid IV length: AES-GCM requires a 12-byte nonce, got {}",
+                    iv_bytes.len()
                 ));
             }
             let mut key_256: [u8; 32] = key_bytes
@@ -2122,6 +2127,65 @@ mod tests {
         assert!(
             verification_result.unwrap(),
             "Compressed token should be valid"
+        );
+    }
+
+    #[test]
+    fn test_decrypt_jwe_rejects_malformed_iv_length() {
+        use base64::Engine;
+        let b64 = |b: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b);
+        let header = b64(br#"{"alg":"dir","enc":"A256GCM"}"#);
+        // IV of 8 bytes — AES-GCM requires a 12-byte nonce. Before the guard this
+        // converted into `Nonce` via `from_slice`, panicking on the length mismatch.
+        let iv = b64(&[0u8; 8]);
+        let ciphertext = b64(&[0u8; 16]);
+        let tag = b64(&[0u8; 16]);
+        // Empty encrypted-key segment is valid for `dir`.
+        let token = format!("{header}..{iv}.{ciphertext}.{tag}");
+        let key = "01234567890123456789012345678901"; // 32 bytes for A256GCM
+
+        let result = decrypt_jwe(&token, key);
+        assert!(
+            result.is_err(),
+            "decrypt_jwe must reject a non-12-byte IV instead of panicking"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Invalid IV length"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_verify_hs384_expired_token_propagates_error() {
+        let secret = "test_secret";
+        let exp = (Utc::now() - Duration::hours(1)).timestamp();
+        let claims = json!({ "sub": "u", "exp": exp });
+        let options = EncodeOptions {
+            algorithm: "HS384",
+            key_data: KeyData::Secret(secret),
+            header_params: None,
+            compress_payload: false,
+        };
+        let token = encode_with_options(&claims, &options).expect("Failed to encode HS384 token");
+
+        let verify_options = VerifyOptions {
+            key_data: VerifyKeyData::Secret(secret),
+            validate_exp: true,
+            validate_nbf: false,
+            leeway: 0,
+        };
+        // Consistent with the HS256/RSA/EC paths: an expired token surfaces as a
+        // distinct error rather than collapsing into Ok(false).
+        let result = verify_with_options(&token, &verify_options);
+        assert!(
+            result.is_err(),
+            "expired HS384 token should propagate an error"
+        );
+        let msg = result.unwrap_err().to_string().to_lowercase();
+        assert!(
+            msg.contains("expired"),
+            "error should mention expiration: {msg}"
         );
     }
 

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -93,7 +93,7 @@ pub fn generate_url_payload(
         let bypass_urls = [
             format!("{}://{}{}{}", protocol, trust_domain, "Z", domain),
             format!("{protocol}://{trust_domain}@{domain}"),
-            format!("{protocol}://{trust_domain}%0d0aHost: {domain}"),
+            format!("{protocol}://{trust_domain}%0d%0aHost: {domain}"),
         ];
 
         for url in &bypass_urls {
@@ -1416,7 +1416,7 @@ mod tests {
                     .unwrap()
                     .as_str()
                     .unwrap()
-                    .contains("victim.com%0d0aHost: attacker.com")
+                    .contains("victim.com%0d%0aHost: attacker.com")
             }),
             "Bypass payload with CRLF not found"
         );


### PR DESCRIPTION
## Summary

A focused correctness review of the core crypto (`jwt/mod.rs`), scan (`cmd/scan.rs`), and payload (`payload/mod.rs`) paths surfaced several genuine defects — not lint noise. This PR fixes the high-confidence ones, each with a regression test that fails against the pre-fix code.

The codebase was already in good shape (clean `fmt`/`clippy`, 302 tests). These changes target real bugs that matter for a security tool: scan **false-negatives** (missed vulnerabilities), a **panic** reachable from untrusted input, and an attack payload that was silently **neutered** by a typo.

## Fixes

| Area | Defect | Fix |
|------|--------|-----|
| `jwt::decrypt_jwe` | A non-12-byte IV from an attacker-controlled JWE **panicked** on the `Nonce` conversion (`GenericArray::from_slice`). | Validate `iv_bytes.len() == 12` up front, return a clear error. |
| `scan::check_psychic_signature` | CVE-2022-21449 (all-zero ECDSA sig) was a **false-negative** on the header-only fallback path and for ES512/P-521, because it read the HS256 sentinel from `decoded.algorithm`. | Read `alg` from the raw header (same idiom as `check_algorithm_confusion`). |
| `scan::check_none_algorithm` | Dead `format!("{:?}", algorithm).contains("none")` clause (no `None` variant exists), and the `alg: ["none", ...]` parser-confusion variant was **not detected**. | Drop the dead clause; match both string and array forms of `none`. |
| `payload` CRLF bypass | Host-header bypass URL used `%0d0a` — the missing `%` left the line feed unencoded, **neutering the bypass**. | `%0d%0a` (the enshrining test was corrected too). |
| `jwt` HS384/HS512 verify | Expired/not-yet-valid tokens collapsed into `Ok(false)`, **inconsistent** with the HS256/RSA/EC paths. | Route through `handle_verification_result` so time errors propagate. |
| `jwt::encode_compressed_jwt` | Dead computation before an unconditional "not yet supported" error. | Removed for clarity. |

## Deliberately out of scope (maintainer's call)

These look like defects but are existing **design decisions with passing tests**, so they were left untouched and are flagged here instead:
- `verify_with_options` treats `alg:none` as valid regardless of the provided key (the no-key verify path depends on this).
- `none` tokens are emitted with a non-standard `''` signature segment (used consistently across encode/scan/tests).

## Testing

- `cargo test --all-features` → **307 passed** (302 prior + 5 new regression tests)
- `cargo clippy --all-targets --all-features -- --deny warnings` → clean
- `cargo fmt --check` → clean
- `cargo doc --workspace --all-features --no-deps --document-private-items` (`-D warnings`) → clean