### PR TITLE
fix: security & correctness hardening across CLI, server, shell, MCP

### DIFF
--- a/src/cmd/decode.rs
+++ b/src/cmd/decode.rs
@@ -1,28 +1,27 @@
 use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
-use std::time::SystemTime;
 
 use crate::jwt;
 use crate::utils;
 
-/// Helper function to format Unix timestamp to human-readable format
-fn format_unix_timestamp(seconds: u64) -> String {
-    let time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(seconds);
-    chrono::DateTime::<chrono::Utc>::from(time)
-        .format("%Y-%m-%d %H:%M:%S UTC")
-        .to_string()
+/// Helper function to format a Unix timestamp to a human-readable string.
+///
+/// Returns `None` for values outside chrono's representable range instead of
+/// panicking, so that attacker-controlled `exp`/`iat` claims cannot crash decode.
+fn format_unix_timestamp(seconds: i64) -> Option<String> {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(seconds, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
 }
 
 /// Annotate issued-at claim with human-readable timestamp in the JSON output
 fn process_issued_at_claim(claims: &Value, claims_map: &mut Value) {
     if let Some(iat) = claims.get("iat") {
-        if let Some(iat_val) = iat.as_f64() {
-            let iat_seconds = iat_val as u64;
-            let formatted_time = format_unix_timestamp(iat_seconds);
-
-            if let Some(obj) = claims_map.as_object_mut() {
-                obj.insert("iat_time".to_string(), Value::String(formatted_time));
+        if let Some(iat_seconds) = iat.as_i64() {
+            if let Some(formatted_time) = format_unix_timestamp(iat_seconds) {
+                if let Some(obj) = claims_map.as_object_mut() {
+                    obj.insert("iat_time".to_string(), Value::String(formatted_time));
+                }
             }
         }
     }
@@ -31,20 +30,18 @@ fn process_issued_at_claim(claims: &Value, claims_map: &mut Value) {
 /// Annotate expiration claim with human-readable timestamp and status in the JSON output
 fn process_expiration_claim(claims: &Value, claims_map: &mut Value) {
     if let Some(exp) = claims.get("exp") {
-        if let Some(exp_val) = exp.as_f64() {
-            let exp_seconds = exp_val as u64;
-            let exp_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(exp_seconds);
-            let formatted_time = format_unix_timestamp(exp_seconds);
+        if let Some(exp_seconds) = exp.as_i64() {
+            if let Some(formatted_time) = format_unix_timestamp(exp_seconds) {
+                let now = chrono::Utc::now().timestamp();
+                let is_expired = now > exp_seconds;
 
-            let now = SystemTime::now();
-            let is_expired = now > exp_time;
-
-            if let Some(obj) = claims_map.as_object_mut() {
-                obj.insert("exp_time".to_string(), Value::String(formatted_time));
-                obj.insert(
-                    "exp_status".to_string(),
-                    Value::String(if is_expired { "EXPIRED" } else { "VALID" }.to_string()),
-                );
+                if let Some(obj) = claims_map.as_object_mut() {
+                    obj.insert("exp_time".to_string(), Value::String(formatted_time));
+                    obj.insert(
+                        "exp_status".to_string(),
+                        Value::String(if is_expired { "EXPIRED" } else { "VALID" }.to_string()),
+                    );
+                }
             }
         }
     }
@@ -232,7 +229,7 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use serde_json::json;
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_execute_valid_token() {
@@ -332,6 +329,24 @@ mod tests {
             result.is_err(),
             "decode_token should fail for invalid token format"
         );
+    }
+
+    #[test]
+    fn test_decode_token_with_overflowing_exp_does_not_panic() {
+        // Attacker-controlled out-of-range exp/iat claims must not crash decode.
+        for value in [
+            json!(8_300_000_000_000_000i64), // out of chrono range
+            json!(i64::MAX),
+            json!(1e30),  // saturates a naive float->u64 cast
+            json!(-1i64), // negative timestamp
+        ] {
+            let claims = json!({ "sub": "u", "exp": value, "iat": value });
+            let token = jwt::encode(&claims, "", "HS256").expect("token");
+            let result = std::panic::catch_unwind(|| {
+                let _ = execute_json(&token);
+            });
+            assert!(result.is_ok(), "decode panicked on exp/iat = {value}");
+        }
     }
 
     #[test]

--- a/src/cmd/decode.rs
+++ b/src/cmd/decode.rs
@@ -14,10 +14,20 @@ fn format_unix_timestamp(seconds: i64) -> Option<String> {
         .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
 }
 
+/// Reads a NumericDate claim (`exp`/`iat`) as seconds. Accepts both integer and
+/// float JSON numbers (RFC 7519 allows non-integer NumericDate). Float→int uses
+/// Rust's saturating cast and non-finite values are rejected; out-of-range values
+/// are later dropped by `format_unix_timestamp` rather than panicking.
+fn claim_seconds(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().filter(|f| f.is_finite()).map(|f| f as i64))
+}
+
 /// Annotate issued-at claim with human-readable timestamp in the JSON output
 fn process_issued_at_claim(claims: &Value, claims_map: &mut Value) {
     if let Some(iat) = claims.get("iat") {
-        if let Some(iat_seconds) = iat.as_i64() {
+        if let Some(iat_seconds) = claim_seconds(iat) {
             if let Some(formatted_time) = format_unix_timestamp(iat_seconds) {
                 if let Some(obj) = claims_map.as_object_mut() {
                     obj.insert("iat_time".to_string(), Value::String(formatted_time));
@@ -30,7 +40,7 @@ fn process_issued_at_claim(claims: &Value, claims_map: &mut Value) {
 /// Annotate expiration claim with human-readable timestamp and status in the JSON output
 fn process_expiration_claim(claims: &Value, claims_map: &mut Value) {
     if let Some(exp) = claims.get("exp") {
-        if let Some(exp_seconds) = exp.as_i64() {
+        if let Some(exp_seconds) = claim_seconds(exp) {
             if let Some(formatted_time) = format_unix_timestamp(exp_seconds) {
                 let now = chrono::Utc::now().timestamp();
                 let is_expired = now > exp_seconds;
@@ -347,6 +357,24 @@ mod tests {
             });
             assert!(result.is_ok(), "decode panicked on exp/iat = {value}");
         }
+    }
+
+    #[test]
+    fn test_decode_token_with_float_timestamp_is_annotated() {
+        // RFC 7519 NumericDate allows non-integer values; a float exp/iat must still
+        // be annotated (not silently dropped) and must not panic.
+        let claims = json!({ "sub": "u", "exp": 1_700_000_000.0_f64, "iat": 1_600_000_000.0_f64 });
+        let token = jwt::encode(&claims, "", "HS256").expect("token");
+        let value = execute_json(&token).expect("decode");
+        let payload = value.get("payload").expect("payload");
+        assert!(
+            payload.get("exp_time").is_some(),
+            "float exp should be annotated with exp_time"
+        );
+        assert!(
+            payload.get("iat_time").is_some(),
+            "float iat should be annotated with iat_time"
+        );
     }
 
     #[test]

--- a/src/cmd/encode.rs
+++ b/src/cmd/encode.rs
@@ -115,7 +115,8 @@ pub fn execute_json(
         (
             jwt::encode_with_options(&claims, &options)?,
             if secret.unwrap_or("").is_empty() {
-                "empty".to_string()
+                // Still an HMAC signature, just keyed with an empty secret — not unsigned.
+                "empty (signed)".to_string()
             } else {
                 "****".to_string()
             },
@@ -225,14 +226,20 @@ fn encode_json(
     // Encode the JWT token using the configured options
     let token = jwt::encode_with_options(&claims, &options)?;
 
-    // Determine key information display based on signature type
-    let key_info = if no_signature || secret.unwrap_or("").is_empty() {
+    // Determine key information display based on signature type. An empty secret
+    // still produces a real (forgeable) HMAC signature, so it must not be reported
+    // as "unsigned" — only the explicit `--no-signature` (none) path is unsigned.
+    let key_info = if no_signature {
         "None (unsigned)".dimmed().to_string()
+    } else if secret.unwrap_or("").is_empty() {
+        "empty secret (signed)".dimmed().to_string()
     } else {
         "****".to_string()
     };
 
-    display_encoding_result(&token, algorithm, &key_info, headers);
+    // Reflect the actual algorithm written into the token: --no-signature emits "none".
+    let effective_alg = if no_signature { "none" } else { algorithm };
+    display_encoding_result(&token, effective_alg, &key_info, headers);
 
     Ok(())
 }

--- a/src/cmd/jwks.rs
+++ b/src/cmd/jwks.rs
@@ -198,8 +198,13 @@ pub fn execute_fetch(url: &str) {
                     "RSA" => {
                         if let Some(n) = &key.n {
                             let n_str: &str = n.as_str();
-                            let n_display = if n_str.len() > 40 {
-                                format!("{}...({} chars)", &n_str[..40], n_str.len())
+                            // The modulus comes verbatim from a remote/attacker-controlled
+                            // JWKS and is not guaranteed to be ASCII; truncate by characters
+                            // so a multibyte boundary at byte 40 cannot panic.
+                            let char_count = n_str.chars().count();
+                            let n_display = if char_count > 40 {
+                                let head: String = n_str.chars().take(40).collect();
+                                format!("{}...({} chars)", head, char_count)
                             } else {
                                 n_str.to_string()
                             };

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -222,6 +222,26 @@ impl JwtHackServer {
         Parameters(args): Parameters<VerifyArgs>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(secret) = &args.secret {
+            // A 'none' token carries no signature. If a (non-empty) secret was supplied,
+            // verifying against it would silently ignore the secret — the classic
+            // alg:none bypass — so report the token as invalid instead, matching the CLI
+            // and REST verify surfaces.
+            if !secret.is_empty() {
+                if let Ok(decoded) = crate::jwt::decode(&args.token) {
+                    let is_none = decoded
+                        .header
+                        .get("alg")
+                        .and_then(|v| v.as_str())
+                        .map(|a| a.eq_ignore_ascii_case("none"))
+                        .unwrap_or(false);
+                    if is_none {
+                        return Ok(CallToolResult::success(vec![Content::text(
+                            "✗ Token uses 'none' algorithm and carries no signature; cannot be verified against the provided secret".to_string(),
+                        )]));
+                    }
+                }
+            }
+
             // Honor the advertised `validate_exp` option instead of silently ignoring
             // it: route through verify_with_options so an expired token is reported as
             // expired rather than "valid" when the caller asked for expiration checks.
@@ -483,6 +503,41 @@ mod tests {
 
         let call_result = result.unwrap();
         assert!(call_result.is_error != Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_verify_tool_rejects_none_with_secret() {
+        let server = JwtHackServer::new();
+        // Build an unsigned 'none' token.
+        let options = crate::jwt::EncodeOptions {
+            algorithm: "none",
+            key_data: crate::jwt::KeyData::None,
+            header_params: None,
+            compress_payload: false,
+        };
+        let token = crate::jwt::encode_with_options(&serde_json::json!({"sub": "admin"}), &options)
+            .unwrap();
+
+        let args = VerifyArgs {
+            token,
+            secret: Some("any-secret".to_string()),
+            validate_exp: false,
+        };
+        let call_result = server.verify(Parameters(args)).await.unwrap();
+        if let Some(content) = call_result.content.first() {
+            if let RawContent::Text(text) = &content.raw {
+                assert!(
+                    !text.text.contains("✓ JWT signature is valid"),
+                    "a none token with a secret must not be reported valid: {}",
+                    text.text
+                );
+                assert!(
+                    text.text.contains("none"),
+                    "expected a 'none' explanation, got: {}",
+                    text.text
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -63,7 +63,6 @@ pub struct VerifyArgs {
     pub secret: Option<String>,
     /// Validate expiration claim (exp)
     #[serde(default)]
-    #[allow(dead_code)]
     pub validate_exp: bool,
 }
 
@@ -86,10 +85,6 @@ pub struct CrackArgs {
     /// Max length for bruteforce attack
     #[serde(default = "default_max_length")]
     pub max: usize,
-    /// Concurrency level
-    #[serde(default = "default_concurrency")]
-    #[allow(dead_code)]
-    pub concurrency: usize,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -125,10 +120,6 @@ fn default_min_length() -> usize {
 
 fn default_max_length() -> usize {
     4
-}
-
-fn default_concurrency() -> usize {
-    20
 }
 
 fn default_payload_target() -> String {
@@ -231,7 +222,16 @@ impl JwtHackServer {
         Parameters(args): Parameters<VerifyArgs>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(secret) = &args.secret {
-            let result = crate::jwt::verify(&args.token, secret);
+            // Honor the advertised `validate_exp` option instead of silently ignoring
+            // it: route through verify_with_options so an expired token is reported as
+            // expired rather than "valid" when the caller asked for expiration checks.
+            let options = crate::jwt::VerifyOptions {
+                key_data: crate::jwt::VerifyKeyData::Secret(secret),
+                validate_exp: args.validate_exp,
+                validate_nbf: false,
+                leeway: 0,
+            };
+            let result = crate::jwt::verify_with_options(&args.token, &options);
 
             match result {
                 Ok(is_valid) => {
@@ -304,15 +304,27 @@ impl JwtHackServer {
                     args.min, args.max
                 ))]));
             }
-            let max_len = std::cmp::min(args.max, 3); // Limit to 3 characters max for MCP
-            let chars: Vec<char> = chars_to_use.chars().take(10).collect(); // Limit charset
+            const MCP_MAX_BRUTE_LEN: usize = 3;
+            const MCP_MAX_CHARSET: usize = 10;
+            const MCP_MAX_ATTEMPTS: usize = 100;
+            let max_len = std::cmp::min(args.max, MCP_MAX_BRUTE_LEN); // Limit length for MCP
+            let chars: Vec<char> = chars_to_use.chars().take(MCP_MAX_CHARSET).collect(); // Limit charset
 
             let min_len = std::cmp::max(args.min, 1);
+            // Without this guard, a requested min length above the MCP cap yields an
+            // empty range (min_len > max_len) and the tool silently reports "not found"
+            // having searched nothing. Reject it explicitly so the caller is not misled.
+            if min_len > max_len {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "MCP brute-force is capped at {} characters; requested min length {} cannot be searched.",
+                    MCP_MAX_BRUTE_LEN, min_len
+                ))]));
+            }
             for len in min_len..=max_len {
                 // Generate combinations for this length
                 let combinations = generate_combinations(&chars, len);
 
-                for combination in combinations.into_iter().take(100) {
+                for combination in combinations.into_iter().take(MCP_MAX_ATTEMPTS) {
                     // Limit attempts
                     if let Ok(is_valid) = crate::jwt::verify(&args.token, &combination) {
                         if is_valid {
@@ -325,10 +337,11 @@ impl JwtHackServer {
                 }
             }
 
-            Ok(CallToolResult::success(vec![Content::text(
-                "✗ Brute force attack failed. Secret not found in limited search space."
-                    .to_string(),
-            )]))
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "✗ Brute force attack failed. Secret not found in the limited MCP search space \
+                 (lengths {}-{}, charset capped at {} chars, {} attempts per length).",
+                min_len, max_len, MCP_MAX_CHARSET, MCP_MAX_ATTEMPTS
+            ))]))
         } else {
             Ok(CallToolResult::error(vec![Content::text(
                 "Invalid crack mode. Use 'dict' or 'brute'.".to_string(),
@@ -487,7 +500,6 @@ mod tests {
             preset: None, // preset
             min: 1,
             max: 2,
-            concurrency: 1,
         };
 
         let result = server.crack(Parameters(args)).await;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -59,9 +59,9 @@ pub enum Commands {
         #[arg(long)]
         private_key: Option<PathBuf>,
 
-        /// Algorithm to use
-        #[arg(long, default_value = "HS256")]
-        algorithm: String,
+        /// Algorithm to use (falls back to config `default_algorithm`, then HS256)
+        #[arg(long)]
+        algorithm: Option<String>,
 
         /// Use 'none' algorithm (no signature)
         #[arg(long)]
@@ -291,8 +291,9 @@ pub enum JwksAction {
 pub fn execute() {
     let cli = Cli::parse();
 
-    // Load configuration
-    let _config = match crate::config::Config::load(cli.config.as_deref()) {
+    // Load configuration. Its `default_*` values are applied below as fallbacks when
+    // the corresponding CLI flag is not provided (CLI flags always take precedence).
+    let config = match crate::config::Config::load(cli.config.as_deref()) {
         Ok(config) => config,
         Err(e) => {
             error!("Failed to load configuration: {}", e);
@@ -312,16 +313,22 @@ pub fn execute() {
                 header,
                 compress,
                 jwe,
-            }) => encode::execute_json(
-                json,
-                secret.as_deref(),
-                private_key.as_ref(),
-                algorithm,
-                *no_signature,
-                header,
-                *compress,
-                *jwe,
-            ),
+            }) => {
+                let algorithm = algorithm
+                    .as_deref()
+                    .or(config.default_algorithm.as_deref())
+                    .unwrap_or("HS256");
+                encode::execute_json(
+                    json,
+                    secret.as_deref().or(config.default_secret.as_deref()),
+                    private_key.as_ref().or(config.default_private_key.as_ref()),
+                    algorithm,
+                    *no_signature,
+                    header,
+                    *compress,
+                    *jwe,
+                )
+            }
             Some(Commands::Verify {
                 token,
                 secret,
@@ -329,8 +336,8 @@ pub fn execute() {
                 validate_exp,
             }) => verify::execute_json(
                 token,
-                secret.as_deref(),
-                private_key.as_ref(),
+                secret.as_deref().or(config.default_secret.as_deref()),
+                private_key.as_ref().or(config.default_private_key.as_ref()),
                 *validate_exp,
             ),
             Some(Commands::Crack {
@@ -346,20 +353,27 @@ pub fn execute() {
                 verbose,
                 target_field,
                 pattern,
-            }) => crack::execute_json(
-                token,
-                mode,
-                wordlist,
-                chars,
-                preset,
-                *concurrency,
-                *min,
-                *max,
-                *power,
-                *verbose,
-                target_field,
-                pattern,
-            ),
+            }) => {
+                let wordlist = if wordlist.is_some() {
+                    wordlist
+                } else {
+                    &config.default_wordlist
+                };
+                crack::execute_json(
+                    token,
+                    mode,
+                    wordlist,
+                    chars,
+                    preset,
+                    *concurrency,
+                    *min,
+                    *max,
+                    *power,
+                    *verbose,
+                    target_field,
+                    pattern,
+                )
+            }
             Some(Commands::Payload {
                 token,
                 jwk_trust,
@@ -385,7 +399,7 @@ pub fn execute() {
                 report.as_ref(),
                 *skip_crack,
                 *skip_payloads,
-                wordlist.as_ref(),
+                wordlist.as_ref().or(config.default_wordlist.as_ref()),
                 *max_crack_attempts,
             ),
             Some(Commands::Jwks { action }) => jwks::execute_json(action),
@@ -422,8 +436,16 @@ pub fn execute() {
                     api_key,
                 }) = &cli.command
                 {
-                    let runtime =
-                        tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+                    let runtime = match tokio::runtime::Runtime::new() {
+                        Ok(rt) => rt,
+                        Err(e) => {
+                            let err_value = crate::output::ErrorResponse::new(format!(
+                                "Failed to create tokio runtime: {e}"
+                            ));
+                            let _ = crate::output::print_json(&err_value);
+                            std::process::exit(1);
+                        }
+                    };
                     if let Some(key) = api_key.as_deref() {
                         runtime.block_on(server::execute_with_api_key(host, *port, key));
                     } else {
@@ -431,13 +453,9 @@ pub fn execute() {
                     }
                 }
 
-                if let Some(Commands::Mcp) = &cli.command {
-                    mcp::execute();
-                }
-
-                if let Some(Commands::Shell) = &cli.command {
-                    shell::execute();
-                }
+                // Note: Mcp/Shell are intentionally not launched here — they return an
+                // error above because `--json` is unsupported for them, so control never
+                // reaches this Ok arm for those subcommands.
             }
             Err(e) => {
                 let err_value = crate::output::ErrorResponse::new(e.to_string());
@@ -463,10 +481,14 @@ pub fn execute() {
             compress,
             jwe,
         }) => {
+            let algorithm = algorithm
+                .as_deref()
+                .or(config.default_algorithm.as_deref())
+                .unwrap_or("HS256");
             encode::execute(
                 json,
-                secret.as_deref(),
-                private_key.as_ref(),
+                secret.as_deref().or(config.default_secret.as_deref()),
+                private_key.as_ref().or(config.default_private_key.as_ref()),
                 algorithm,
                 *no_signature,
                 header,
@@ -482,8 +504,8 @@ pub fn execute() {
         }) => {
             verify::execute(
                 token,
-                secret.as_deref(),
-                private_key.as_ref(),
+                secret.as_deref().or(config.default_secret.as_deref()),
+                private_key.as_ref().or(config.default_private_key.as_ref()),
                 *validate_exp,
             );
         }
@@ -501,6 +523,11 @@ pub fn execute() {
             target_field,
             pattern,
         }) => {
+            let wordlist = if wordlist.is_some() {
+                wordlist
+            } else {
+                &config.default_wordlist
+            };
             crack::execute(
                 token,
                 mode,
@@ -544,7 +571,7 @@ pub fn execute() {
                 report.as_ref(),
                 *skip_crack,
                 *skip_payloads,
-                wordlist.as_ref(),
+                wordlist.as_ref().or(config.default_wordlist.as_ref()),
                 *max_crack_attempts,
             );
         }
@@ -596,7 +623,13 @@ pub fn execute() {
             port,
             api_key,
         }) => {
-            let runtime = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+            let runtime = match tokio::runtime::Runtime::new() {
+                Ok(rt) => rt,
+                Err(e) => {
+                    error!("Failed to create tokio runtime: {e}");
+                    std::process::exit(1);
+                }
+            };
             if let Some(key) = api_key.as_deref() {
                 runtime.block_on(server::execute_with_api_key(host, *port, key));
             } else {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -310,6 +310,12 @@ async fn handle_verify(Json(req): Json<VerifyRequest>) -> Result<Json<VerifyResp
 /// Bounds memory/time and prevents pointing the endpoint at huge or special files.
 const MAX_WORDLIST_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 
+/// Bounds how many crack/scan operations run concurrently. `spawn_blocking` already
+/// keeps a single crack off the async runtime, but without this cap a burst of
+/// requests could still occupy many blocking threads and saturate CPU. Excess
+/// requests wait asynchronously for a permit instead of piling on.
+static CRACK_LIMITER: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(4);
+
 /// Helper function to crack JWT using dictionary attack
 fn crack_dict(token: &str, wordlist_path: &PathBuf) -> anyhow::Result<Option<String>> {
     use std::fs::File;
@@ -405,6 +411,12 @@ fn crack_brute(
 
 /// Crack endpoint handler
 async fn handle_crack(Json(req): Json<CrackRequest>) -> Result<Json<CrackResponse>, ApiError> {
+    // Limit concurrent crack work across all requests (released when this handler returns).
+    let _permit = CRACK_LIMITER.acquire().await.map_err(|e| ApiError {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        message: format!("crack limiter unavailable: {e}"),
+    })?;
+
     // Run the synchronous, CPU/IO-bound crack on a blocking thread so it cannot pin
     // a Tokio worker and starve /health and every other endpoint (request DoS).
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<Option<String>> {
@@ -536,6 +548,10 @@ async fn handle_scan(Json(req): Json<ScanRequest>) -> Result<Json<ScanResponse>,
     // read/verify loop does not block the async runtime.
     if !req.skip_crack {
         if let Some(wordlist_path) = &req.wordlist {
+            let _permit = CRACK_LIMITER.acquire().await.map_err(|e| ApiError {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                message: format!("crack limiter unavailable: {e}"),
+            })?;
             let token = req.token.clone();
             let path = PathBuf::from(wordlist_path);
             let crack_result = tokio::task::spawn_blocking(move || crack_dict(&token, &path))

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -71,6 +71,12 @@ pub struct CrackRequest {
     pub token: String,
     #[serde(default = "default_crack_mode")]
     pub mode: String,
+    /// Inline wordlist (one secret per entry). Preferred over `wordlist` in server
+    /// mode so clients never need the server to open a server-side file path.
+    #[serde(default)]
+    pub wordlist_content: Option<Vec<String>>,
+    /// Server-side wordlist file path. Only honored when it resolves inside the
+    /// directory named by the `JWT_HACK_WORDLIST_DIR` env var (otherwise rejected).
     #[serde(default)]
     pub wordlist: Option<String>,
     #[serde(default = "default_crack_chars")]
@@ -149,6 +155,10 @@ pub struct ScanRequest {
     pub skip_crack: bool,
     #[serde(default)]
     pub skip_payloads: bool,
+    /// Inline wordlist (one secret per entry); preferred over `wordlist`.
+    #[serde(default)]
+    pub wordlist_content: Option<Vec<String>>,
+    /// Server-side wordlist file path, gated by `JWT_HACK_WORDLIST_DIR` (see CrackRequest).
     #[serde(default)]
     pub wordlist: Option<String>,
     #[serde(default = "default_max_crack_attempts")]
@@ -316,14 +326,77 @@ const MAX_WORDLIST_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 /// requests wait asynchronously for a permit instead of piling on.
 static CRACK_LIMITER: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(4);
 
-/// Helper function to crack JWT using dictionary attack
+/// Where a dictionary attack draws its candidate secrets from.
+enum WordlistSource {
+    /// Candidates sent inline in the request body.
+    Inline(Vec<String>),
+    /// An allow-list-validated server-side file path.
+    Path(PathBuf),
+}
+
+impl WordlistSource {
+    /// Run the dictionary attack for this source (intended for a blocking thread).
+    fn crack(self, token: &str) -> anyhow::Result<Option<String>> {
+        match self {
+            WordlistSource::Inline(words) => Ok(crack_words(token, words)),
+            WordlistSource::Path(path) => crack_dict(token, &path),
+        }
+    }
+}
+
+/// Resolve the dictionary source from a request: inline content is preferred, then a
+/// gated file path. Returns `Ok(None)` when neither was supplied.
+fn wordlist_source(
+    content: Option<Vec<String>>,
+    path: Option<&String>,
+) -> anyhow::Result<Option<WordlistSource>> {
+    if let Some(words) = content {
+        Ok(Some(WordlistSource::Inline(words)))
+    } else if let Some(path) = path {
+        Ok(Some(WordlistSource::Path(resolve_wordlist_path(path)?)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Try each candidate secret against the token, returning the first that verifies.
+fn crack_words<I: IntoIterator<Item = String>>(token: &str, words: I) -> Option<String> {
+    words
+        .into_iter()
+        .find(|word| matches!(jwt::verify(token, word), Ok(true)))
+}
+
+/// Resolve a client-supplied wordlist path against the operator-configured allow-list.
+///
+/// In server mode the path originates from a remote request body, so opening an
+/// arbitrary path would be an unauthenticated file-read primitive. We only honor
+/// paths that canonicalize to a location inside `JWT_HACK_WORDLIST_DIR` (which also
+/// defeats `..` traversal and symlink escapes). If the env var is unset, server-side
+/// paths are disabled entirely and clients must send `wordlist_content` inline.
+fn resolve_wordlist_path(requested: &str) -> anyhow::Result<PathBuf> {
+    let base = std::env::var_os("JWT_HACK_WORDLIST_DIR").ok_or_else(|| {
+        anyhow::anyhow!(
+            "server-side wordlist file paths are disabled; send `wordlist_content` inline, \
+             or set JWT_HACK_WORDLIST_DIR to an allowed directory to enable path-based wordlists"
+        )
+    })?;
+    let base = std::fs::canonicalize(&base)
+        .map_err(|e| anyhow::anyhow!("JWT_HACK_WORDLIST_DIR is not accessible: {}", e))?;
+    let candidate = std::fs::canonicalize(PathBuf::from(requested))
+        .map_err(|e| anyhow::anyhow!("wordlist path is not accessible: {}", e))?;
+    if !candidate.starts_with(&base) {
+        anyhow::bail!("wordlist path is outside the allowed directory");
+    }
+    Ok(candidate)
+}
+
+/// Helper function to crack JWT using a dictionary file (already allow-list validated).
 fn crack_dict(token: &str, wordlist_path: &PathBuf) -> anyhow::Result<Option<String>> {
     use std::fs::File;
     use std::io::{BufRead, BufReader, Read};
 
-    // The wordlist path arrives from the request body in server mode. Reject
-    // non-regular files (directories, devices like /dev/zero, FIFOs) and oversized
-    // files so a client cannot turn the endpoint into a blocking/DoS file reader.
+    // Reject non-regular files (directories, devices like /dev/zero, FIFOs) and
+    // oversized files so the endpoint can't be turned into a blocking/DoS file reader.
     let metadata = std::fs::metadata(wordlist_path)?;
     if !metadata.is_file() {
         anyhow::bail!("wordlist path is not a regular file");
@@ -339,13 +412,7 @@ fn crack_dict(token: &str, wordlist_path: &PathBuf) -> anyhow::Result<Option<Str
     let file = File::open(wordlist_path)?;
     let reader = BufReader::new(file).take(MAX_WORDLIST_BYTES);
 
-    for word in reader.lines().map_while(Result::ok) {
-        if let Ok(true) = jwt::verify(token, &word) {
-            return Ok(Some(word));
-        }
-    }
-
-    Ok(None)
+    Ok(crack_words(token, reader.lines().map_while(Result::ok)))
 }
 
 /// Helper function to crack JWT using brute force
@@ -422,12 +489,12 @@ async fn handle_crack(Json(req): Json<CrackRequest>) -> Result<Json<CrackRespons
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<Option<String>> {
         let mode = req.mode.to_lowercase();
         match mode.as_str() {
-            "dict" => {
-                let wordlist_path = req.wordlist.ok_or_else(|| {
-                    anyhow::anyhow!("Wordlist path required for dictionary attack")
-                })?;
-                crack_dict(&req.token, &PathBuf::from(wordlist_path))
-            }
+            "dict" => match wordlist_source(req.wordlist_content, req.wordlist.as_ref())? {
+                Some(source) => source.crack(&req.token),
+                None => anyhow::bail!(
+                    "Dictionary attack requires `wordlist_content` (inline) or `wordlist` (path)"
+                ),
+            },
             "brute" => {
                 let charset: String = if let Some(preset) = &req.preset {
                     match preset.as_str() {
@@ -547,14 +614,20 @@ async fn handle_scan(Json(req): Json<ScanRequest>) -> Result<Json<ScanResponse>,
     // Try to crack if not skipped. Offload to a blocking thread so the dictionary
     // read/verify loop does not block the async runtime.
     if !req.skip_crack {
-        if let Some(wordlist_path) = &req.wordlist {
+        let source = match wordlist_source(req.wordlist_content.clone(), req.wordlist.as_ref()) {
+            Ok(source) => source,
+            Err(e) => {
+                vulnerabilities.push(format!("Wordlist rejected: {}", e));
+                None
+            }
+        };
+        if let Some(source) = source {
             let _permit = CRACK_LIMITER.acquire().await.map_err(|e| ApiError {
                 status: StatusCode::SERVICE_UNAVAILABLE,
                 message: format!("crack limiter unavailable: {e}"),
             })?;
             let token = req.token.clone();
-            let path = PathBuf::from(wordlist_path);
-            let crack_result = tokio::task::spawn_blocking(move || crack_dict(&token, &path))
+            let crack_result = tokio::task::spawn_blocking(move || source.crack(&token))
                 .await
                 .map_err(|e| ApiError {
                     status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -859,5 +932,38 @@ mod tests {
         let result = crack_brute(&token, "abc", 1, 2);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_wordlist_source_prefers_inline() {
+        // Inline content wins and never touches the filesystem or the env allow-list.
+        let path = "/etc/passwd".to_string();
+        let src = wordlist_source(Some(vec!["a".to_string()]), Some(&path)).unwrap();
+        assert!(matches!(src, Some(WordlistSource::Inline(_))));
+        // Neither source supplied -> no crack source.
+        assert!(wordlist_source(None, None).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_handle_crack_inline_wordlist() {
+        let token = jwt::encode(&serde_json::json!({"sub": "x"}), "letmein", "HS256").unwrap();
+        let req = CrackRequest {
+            token,
+            mode: "dict".to_string(),
+            wordlist_content: Some(vec![
+                "nope".to_string(),
+                "letmein".to_string(),
+                "other".to_string(),
+            ]),
+            wordlist: None,
+            chars: default_crack_chars(),
+            preset: None,
+            concurrency: 1,
+            min: 1,
+            max: 4,
+        };
+        let resp = handle_crack(Json(req)).await.unwrap().0;
+        assert!(resp.success);
+        assert_eq!(resp.secret.as_deref(), Some("letmein"));
     }
 }

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -257,6 +257,29 @@ async fn handle_encode(Json(req): Json<EncodeRequest>) -> Result<Json<EncodeResp
 
 /// Verify endpoint handler
 async fn handle_verify(Json(req): Json<VerifyRequest>) -> Result<Json<VerifyResponse>, ApiError> {
+    // A 'none' token carries no signature. If the caller supplied a (non-empty)
+    // secret, reporting it as valid would silently ignore that secret — the classic
+    // alg:none bypass — so report it as invalid instead.
+    if req.secret.as_deref().map(|s| !s.is_empty()).unwrap_or(false) {
+        if let Ok(decoded) = jwt::decode(&req.token) {
+            let is_none = decoded
+                .header
+                .get("alg")
+                .and_then(|v| v.as_str())
+                .map(|a| a.eq_ignore_ascii_case("none"))
+                .unwrap_or(false);
+            if is_none {
+                return Ok(Json(VerifyResponse {
+                    success: true,
+                    valid: Some(false),
+                    error: Some(
+                        "Token uses 'none' algorithm and carries no signature; cannot be verified against the provided secret".to_string(),
+                    ),
+                }));
+            }
+        }
+    }
+
     let options = jwt::VerifyOptions {
         key_data: jwt::VerifyKeyData::Secret(req.secret.as_deref().unwrap_or("")),
         validate_exp: req.validate_exp,
@@ -278,13 +301,32 @@ async fn handle_verify(Json(req): Json<VerifyRequest>) -> Result<Json<VerifyResp
     }
 }
 
+/// Maximum wordlist size (bytes) the server will read for a dictionary attack.
+/// Bounds memory/time and prevents pointing the endpoint at huge or special files.
+const MAX_WORDLIST_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
+
 /// Helper function to crack JWT using dictionary attack
 fn crack_dict(token: &str, wordlist_path: &PathBuf) -> anyhow::Result<Option<String>> {
     use std::fs::File;
-    use std::io::{BufRead, BufReader};
+    use std::io::{BufRead, BufReader, Read};
+
+    // The wordlist path arrives from the request body in server mode. Reject
+    // non-regular files (directories, devices like /dev/zero, FIFOs) and oversized
+    // files so a client cannot turn the endpoint into a blocking/DoS file reader.
+    let metadata = std::fs::metadata(wordlist_path)?;
+    if !metadata.is_file() {
+        anyhow::bail!("wordlist path is not a regular file");
+    }
+    if metadata.len() > MAX_WORDLIST_BYTES {
+        anyhow::bail!(
+            "wordlist file is too large ({} bytes, limit {} bytes)",
+            metadata.len(),
+            MAX_WORDLIST_BYTES
+        );
+    }
 
     let file = File::open(wordlist_path)?;
-    let reader = BufReader::new(file);
+    let reader = BufReader::new(file).take(MAX_WORDLIST_BYTES);
 
     for word in reader.lines().map_while(Result::ok) {
         if let Ok(true) = jwt::verify(token, &word) {
@@ -320,6 +362,27 @@ fn crack_brute(
         );
     }
 
+    // Bound the total keyspace a single HTTP request can enumerate. The per-length
+    // cap above does NOT bound runtime (e.g. a 62-char charset at length 8 is ~2e14
+    // candidates), which would pin a worker for an unbounded time. Reject requests
+    // whose keyspace exceeds a ceiling that still responds promptly.
+    const MAX_BRUTE_CANDIDATES: u128 = 5_000_000;
+    let charset_size = chars.chars().count() as u128;
+    let mut total: u128 = 0;
+    for length in min_length..=max_length {
+        total = total.saturating_add(charset_size.saturating_pow(length as u32));
+        if total > MAX_BRUTE_CANDIDATES {
+            anyhow::bail!(
+                "requested brute-force keyspace is too large for the server endpoint \
+                 (charset {} chars, lengths {}-{} exceed the {} candidate ceiling)",
+                charset_size,
+                min_length,
+                max_length,
+                MAX_BRUTE_CANDIDATES
+            );
+        }
+    }
+
     // Stream combinations chunk by chunk instead of loading all into memory
     const CHUNK_SIZE: usize = 10000;
     for length in min_length..=max_length {
@@ -337,46 +400,44 @@ fn crack_brute(
 
 /// Crack endpoint handler
 async fn handle_crack(Json(req): Json<CrackRequest>) -> Result<Json<CrackResponse>, ApiError> {
-    let mode = req.mode.to_lowercase();
-
-    // For API, we need to handle cracking without blocking too long
-    let result = match mode.as_str() {
-        "dict" => {
-            if let Some(wordlist_path) = req.wordlist {
-                let path = PathBuf::from(wordlist_path);
-                crack_dict(&req.token, &path)
-            } else {
-                return Ok(Json(CrackResponse {
-                    success: false,
-                    secret: None,
-                    error: Some("Wordlist path required for dictionary attack".to_string()),
-                }));
+    // Run the synchronous, CPU/IO-bound crack on a blocking thread so it cannot pin
+    // a Tokio worker and starve /health and every other endpoint (request DoS).
+    let result = tokio::task::spawn_blocking(move || -> anyhow::Result<Option<String>> {
+        let mode = req.mode.to_lowercase();
+        match mode.as_str() {
+            "dict" => {
+                let wordlist_path = req.wordlist.ok_or_else(|| {
+                    anyhow::anyhow!("Wordlist path required for dictionary attack")
+                })?;
+                crack_dict(&req.token, &PathBuf::from(wordlist_path))
             }
+            "brute" => {
+                let charset: String = if let Some(preset) = &req.preset {
+                    match preset.as_str() {
+                        "az" => "abcdefghijklmnopqrstuvwxyz".to_string(),
+                        "AZ" => "ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_string(),
+                        "aZ" => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".to_string(),
+                        "19" => "0123456789".to_string(),
+                        "aZ19" => {
+                            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+                                .to_string()
+                        }
+                        "ascii" => " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~".to_string(),
+                        _ => req.chars.clone(),
+                    }
+                } else {
+                    req.chars.clone()
+                };
+                crack_brute(&req.token, &charset, req.min, req.max)
+            }
+            other => anyhow::bail!("Invalid mode: {}. Use 'dict' or 'brute'", other),
         }
-        "brute" => {
-            let charset = if let Some(preset) = &req.preset {
-                match preset.as_str() {
-                    "az" => "abcdefghijklmnopqrstuvwxyz",
-                    "AZ" => "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-                    "aZ" => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
-                    "19" => "0123456789",
-                    "aZ19" => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
-                    "ascii" => " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
-                    _ => &req.chars,
-                }
-            } else {
-                &req.chars
-            };
-            crack_brute(&req.token, charset, req.min, req.max)
-        }
-        _ => {
-            return Ok(Json(CrackResponse {
-                success: false,
-                secret: None,
-                error: Some(format!("Invalid mode: {}. Use 'dict' or 'brute'", mode)),
-            }));
-        }
-    };
+    })
+    .await
+    .map_err(|e| ApiError {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: format!("crack task failed: {e}"),
+    })?;
 
     match result {
         Ok(Some(secret)) => Ok(Json(CrackResponse {
@@ -466,11 +527,19 @@ async fn handle_scan(Json(req): Json<ScanRequest>) -> Result<Json<ScanResponse>,
         }
     }
 
-    // Try to crack if not skipped
+    // Try to crack if not skipped. Offload to a blocking thread so the dictionary
+    // read/verify loop does not block the async runtime.
     if !req.skip_crack {
         if let Some(wordlist_path) = &req.wordlist {
+            let token = req.token.clone();
             let path = PathBuf::from(wordlist_path);
-            if let Ok(Some(secret)) = crack_dict(&req.token, &path) {
+            let crack_result = tokio::task::spawn_blocking(move || crack_dict(&token, &path))
+                .await
+                .map_err(|e| ApiError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: format!("scan crack task failed: {e}"),
+                })?;
+            if let Ok(Some(secret)) = crack_result {
                 vulnerabilities.push(format!("Weak secret found: {}", secret));
                 found_secret = Some(secret);
             }
@@ -501,7 +570,12 @@ async fn api_key_middleware(
 ) -> Response {
     if let Some(expected) = expected_key.as_deref() {
         let provided = req.headers().get("X-API-KEY").and_then(|v| v.to_str().ok());
-        if provided != Some(expected) {
+        // Constant-time comparison to avoid leaking how many leading bytes match
+        // via response timing (a byte-by-byte key-recovery side channel).
+        let authorized = provided
+            .map(|p| crate::utils::constant_time_eq(p.as_bytes(), expected.as_bytes()))
+            .unwrap_or(false);
+        if !authorized {
             return (
                 StatusCode::UNAUTHORIZED,
                 axum::Json(serde_json::json!({

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -260,7 +260,12 @@ async fn handle_verify(Json(req): Json<VerifyRequest>) -> Result<Json<VerifyResp
     // A 'none' token carries no signature. If the caller supplied a (non-empty)
     // secret, reporting it as valid would silently ignore that secret — the classic
     // alg:none bypass — so report it as invalid instead.
-    if req.secret.as_deref().map(|s| !s.is_empty()).unwrap_or(false) {
+    if req
+        .secret
+        .as_deref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+    {
         if let Ok(decoded) = jwt::decode(&req.token) {
             let is_none = decoded
                 .header

--- a/src/cmd/shell/capture.rs
+++ b/src/cmd/shell/capture.rs
@@ -1,7 +1,14 @@
 use std::io::Read;
+use std::sync::{Mutex, TryLockError};
 
 use ansi_to_tui::IntoText;
 use ratatui::text::Text;
+
+/// Serializes access to the process-global stdout/stderr redirection performed by
+/// `gag::BufferRedirect`. Without it, two overlapping captures (e.g. a background
+/// `crack` thread and another command) race on the same OS fds: the loser silently
+/// runs with no redirect, leaking raw output onto the TUI and losing its own output.
+static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Result of capturing stdout/stderr from a command
 #[allow(dead_code)]
@@ -16,6 +23,21 @@ pub fn capture_command_output<F>(f: F) -> CapturedOutput
 where
     F: FnOnce(),
 {
+    // Hold the global capture lock for the entire redirect + restore. If another
+    // capture is already active we refuse rather than block (avoiding a UI freeze)
+    // or corrupt the screen (avoiding the silent no-redirect fallback below).
+    let _guard = match CAPTURE_LOCK.try_lock() {
+        Ok(guard) => guard,
+        Err(TryLockError::WouldBlock) => {
+            const BUSY: &str = "(another command is still running — please wait and retry)";
+            return CapturedOutput {
+                text: Text::raw(BUSY),
+                raw: BUSY.to_string(),
+            };
+        }
+        Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+    };
+
     let mut stdout_capture = match gag::BufferRedirect::stdout() {
         Ok(c) => c,
         Err(_) => {

--- a/src/cmd/shell/mod.rs
+++ b/src/cmd/shell/mod.rs
@@ -512,6 +512,19 @@ fn render_help(app: &mut App) {
             .push(Line::from(Span::styled(ex, dim_style)));
     }
 
+    app.output_lines.lines.push(Line::raw(""));
+    app.output_lines
+        .lines
+        .push(Line::from(Span::styled("  Notes", bold_style)));
+    app.output_lines.lines.push(Line::from(Span::styled(
+        "    crack/scan run in the background, one at a time. While one is running,",
+        dim_style,
+    )));
+    app.output_lines.lines.push(Line::from(Span::styled(
+        "    another command may report it is busy — wait for it to finish and retry.",
+        dim_style,
+    )));
+
     app.scroll_to_bottom();
 }
 

--- a/src/cmd/shell/mod.rs
+++ b/src/cmd/shell/mod.rs
@@ -185,6 +185,18 @@ pub fn execute() {
 }
 
 fn run_tui() -> io::Result<()> {
+    // Install a panic hook that restores the terminal before the default hook runs,
+    // so an unexpected panic in the event loop never leaves the user in raw mode on
+    // the alternate screen (which would otherwise require a manual `reset`). This is
+    // the reliable cleanup path under the release profile's panic = "abort" setting,
+    // where unwinding-based cleanup does not run.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        previous_hook(info);
+    }));
+
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -351,13 +363,17 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
                 app.cursor_position = 0;
             }
         },
-        // Left arrow
+        // Left arrow — step back one whole character (cursor_position is a byte offset)
         (_, KeyCode::Left) if app.cursor_position > 0 => {
-            app.cursor_position -= 1;
+            if let Some(c) = app.input[..app.cursor_position].chars().next_back() {
+                app.cursor_position -= c.len_utf8();
+            }
         }
-        // Right arrow
+        // Right arrow — step forward one whole character
         (_, KeyCode::Right) if app.cursor_position < app.input.len() => {
-            app.cursor_position += 1;
+            if let Some(c) = app.input[app.cursor_position..].chars().next() {
+                app.cursor_position += c.len_utf8();
+            }
         }
         // Home
         (_, KeyCode::Home) => {
@@ -376,19 +392,21 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
         (_, KeyCode::PageDown) => {
             app.scroll_offset += app.visible_height();
         }
-        // Backspace
+        // Backspace — remove the whole character before the cursor
         (_, KeyCode::Backspace) if app.cursor_position > 0 => {
-            app.input.remove(app.cursor_position - 1);
-            app.cursor_position -= 1;
+            if let Some(c) = app.input[..app.cursor_position].chars().next_back() {
+                app.cursor_position -= c.len_utf8();
+                app.input.remove(app.cursor_position);
+            }
         }
-        // Delete
+        // Delete — remove the character at the cursor (cursor stays on a char boundary)
         (_, KeyCode::Delete) if app.cursor_position < app.input.len() => {
             app.input.remove(app.cursor_position);
         }
-        // Character input
+        // Character input — advance by the byte length of the inserted character
         (_, KeyCode::Char(c)) => {
             app.input.insert(app.cursor_position, c);
-            app.cursor_position += 1;
+            app.cursor_position += c.len_utf8();
         }
         _ => {}
     }
@@ -521,13 +539,7 @@ fn render_show(app: &mut App) {
         .session
         .token
         .as_deref()
-        .map(|t| {
-            if t.len() > 40 {
-                format!("{}...{}", &t[..20], &t[t.len() - 10..])
-            } else {
-                t.to_string()
-            }
-        })
+        .map(|t| utils::abbreviate_middle(t, 20, 10))
         .unwrap_or_else(|| "(not set)".to_string());
     let token_style = if app.session.token.is_some() {
         default_style
@@ -590,11 +602,7 @@ fn handle_set(parts: &[&str], app: &mut App) {
     match key {
         "token" => {
             app.session.token = Some(value.to_string());
-            let preview = if value.len() > 40 {
-                format!("{}...{}", &value[..20], &value[value.len() - 10..])
-            } else {
-                value.to_string()
-            };
+            let preview = utils::abbreviate_middle(value, 20, 10);
             app.push_success(&format!("Token set: {preview}"));
         }
         "secret" => {

--- a/src/cmd/verify.rs
+++ b/src/cmd/verify.rs
@@ -106,29 +106,38 @@ fn verify_token(
 
     let private_key_content: String; // Needs to live long enough
 
+    // Inspect the token's declared algorithm up front. A 'none' token carries no
+    // signature, so verify_with_options reports it as valid unconditionally. That is
+    // the desired behaviour only when the caller is just inspecting an unsigned token
+    // (no key supplied); if the caller explicitly provided a key/secret, accepting a
+    // 'none' token would silently ignore that key — the classic alg:none bypass — so
+    // we reject it instead.
+    let is_none_alg = jwt::decode(token)?
+        .header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .map(|a| a.eq_ignore_ascii_case("none"))
+        .unwrap_or(false);
+
     if let Some(pk_path) = private_key_path {
+        if is_none_alg {
+            return Err(anyhow!("Token uses the 'none' algorithm and carries no signature; it cannot be verified against the provided private key."));
+        }
         // For asymmetric algorithms, read the private key file
         private_key_content = fs::read_to_string(pk_path)
             .map_err(|e| anyhow!("Failed to read private key from {:?}: {}", pk_path, e))?;
         key_data = VerifyKeyData::PublicKeyPem(&private_key_content);
     } else if let Some(s) = secret {
+        if is_none_alg {
+            return Err(anyhow!("Token uses the 'none' algorithm and carries no signature; it cannot be verified against the provided secret."));
+        }
         // For HMAC algorithms, use the provided secret
         key_data = VerifyKeyData::Secret(s);
+    } else if is_none_alg {
+        // No key provided: allow inspection of the unsigned 'none' token.
+        key_data = VerifyKeyData::Secret("");
     } else {
-        // Handle case where no key/secret is provided
-        // Check if token uses 'none' algorithm which doesn't require verification
-        let decoded_unverified = jwt::decode(token)?;
-        if decoded_unverified
-            .header
-            .get("alg")
-            .and_then(|v| v.as_str())
-            == Some("none")
-        {
-            // For 'none' algorithm, use empty secret (will be ignored)
-            key_data = VerifyKeyData::Secret("");
-        } else {
-            return Err(anyhow!("No secret or private key provided for a token that is not using 'none' algorithm. Please provide --secret or --private-key."));
-        }
+        return Err(anyhow!("No secret or private key provided for a token that is not using 'none' algorithm. Please provide --secret or --private-key."));
     }
 
     let options = VerifyOptions {
@@ -257,6 +266,31 @@ mod tests {
             result.unwrap(),
             "Token with 'none' algorithm should verify without secret"
         );
+    }
+
+    #[test]
+    fn test_verify_token_none_algorithm_with_secret_is_rejected() {
+        // A 'none' token must NOT be reported valid when the caller supplies a key.
+        let claims = json!({"sub": "admin"});
+        let options = jwt::EncodeOptions {
+            algorithm: "none",
+            key_data: jwt::KeyData::None,
+            header_params: None,
+            compress_payload: false,
+        };
+        let token =
+            jwt::encode_with_options(&claims, &options).expect("Failed to create none token");
+
+        // With a secret provided, verification must error rather than return Ok(true).
+        let result = verify_token(&token, Some("any-secret"), None, false);
+        assert!(
+            result.is_err(),
+            "none token with an explicit secret must not be accepted as valid"
+        );
+
+        // Without a key, inspecting the unsigned token is still allowed.
+        let result = verify_token(&token, None, None, false);
+        assert!(matches!(result, Ok(true)));
     }
 
     #[test]

--- a/src/jwks/mod.rs
+++ b/src/jwks/mod.rs
@@ -186,12 +186,24 @@ fn asn1_sequence(items: &[&[u8]]) -> Vec<u8> {
 
 fn asn1_length(len: usize) -> Vec<u8> {
     if len < 128 {
-        vec![len as u8]
-    } else if len < 256 {
-        vec![0x81, len as u8]
-    } else {
-        vec![0x82, (len >> 8) as u8, len as u8]
+        // Short form.
+        return vec![len as u8];
     }
+    // Long form: a leading byte 0x80|N followed by N big-endian length bytes.
+    // The previous implementation hard-coded the 0x82 (2-byte) form, which
+    // silently truncated the length for content >= 65536 bytes and produced
+    // corrupt DER. This emits the minimal number of length bytes for any size.
+    let mut bytes = Vec::new();
+    let mut remaining = len;
+    while remaining > 0 {
+        bytes.push((remaining & 0xff) as u8);
+        remaining >>= 8;
+    }
+    bytes.reverse();
+    let mut out = Vec::with_capacity(bytes.len() + 1);
+    out.push(0x80 | bytes.len() as u8);
+    out.extend_from_slice(&bytes);
+    out
 }
 
 /// Generate a spoofed JWKS with a new RSA key pair
@@ -702,6 +714,10 @@ mod tests {
         assert_eq!(asn1_length(128), vec![0x81, 0x80]);
         assert_eq!(asn1_length(255), vec![0x81, 0xff]);
         assert_eq!(asn1_length(256), vec![0x82, 0x01, 0x00]);
+        assert_eq!(asn1_length(65535), vec![0x82, 0xff, 0xff]);
+        // Lengths >= 65536 must use a 3+ byte long form rather than truncating.
+        assert_eq!(asn1_length(65536), vec![0x83, 0x01, 0x00, 0x00]);
+        assert_eq!(asn1_length(70000), vec![0x83, 0x01, 0x11, 0x70]);
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -170,11 +170,24 @@ pub fn encode_with_options(claims: &Value, options: &EncodeOptions) -> Result<St
     let mut header = Header::new(algorithm);
     if let Some(params) = &options.header_params {
         for (key, value) in params {
-            // Add custom headers as additional claims
+            // Map recognized header fields onto the typed `Header`, and serialize any
+            // other custom parameter through the flattened `extras` map so it is
+            // actually written into the encoded token. Previously every header except
+            // `typ`/`cty` was silently dropped on this (signed, non-compressed) path,
+            // which made `--header kid=...` a no-op and broke targeted-field cracking.
             match *key {
                 "typ" => header.typ = Some(value.to_string()),
                 "cty" => header.cty = Some(value.to_string()),
-                _ => { /* Other headers will be handled by jsonwebtoken */ }
+                "kid" => header.kid = Some(value.to_string()),
+                "jku" => header.jku = Some(value.to_string()),
+                "x5u" => header.x5u = Some(value.to_string()),
+                "x5t" => header.x5t = Some(value.to_string()),
+                // `alg` is determined by the algorithm option; never override it here
+                // (doing so would emit a duplicate "alg" key in the header JSON).
+                "alg" => {}
+                other => {
+                    header.extras.insert(other.to_string(), value.to_string());
+                }
             }
         }
     }
@@ -532,7 +545,7 @@ impl Hs256Verifier {
     /// Return true if `secret` produces the token's signature.
     pub fn verify(&self, secret: &[u8]) -> bool {
         let mut calculated = hmac_sha256::HMAC::mac(&self.signing_input, secret);
-        let matches = calculated.as_slice() == self.expected_sig.as_slice();
+        let matches = crate::utils::constant_time_eq(calculated.as_slice(), &self.expected_sig);
         calculated.zeroize();
         matches
     }
@@ -579,6 +592,13 @@ fn create_validation(algorithm: Algorithm, options: &VerifyOptions) -> Validatio
     validation.validate_exp = options.validate_exp;
     validation.validate_nbf = options.validate_nbf;
     validation.leeway = options.leeway;
+    // jsonwebtoken's defaults require an `exp` claim to be present and validate the
+    // `aud` claim. jwt-hack verifies the SIGNATURE (and optionally exp/nbf) of
+    // arbitrary tokens, so it must not reject a validly-signed token merely because
+    // it lacks `exp` or carries an `aud` we were never asked to check. Without this,
+    // HS384/HS512/RSA/EC tokens that omit `exp` were silently reported as invalid.
+    validation.required_spec_claims.clear();
+    validation.validate_aud = false;
     validation
 }
 
@@ -645,7 +665,8 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
                     // Manual signature check
                     let mut calculated_sig =
                         hmac_sha256::HMAC::mac(message.as_bytes(), secret.as_bytes());
-                    let sig_matches = signature == calculated_sig.as_slice();
+                    let sig_matches =
+                        crate::utils::constant_time_eq(&signature, calculated_sig.as_slice());
                     calculated_sig.zeroize();
                     if !sig_matches {
                         return Ok(false); // Signature mismatch
@@ -2154,6 +2175,46 @@ mod tests {
             msg.contains("Invalid IV length"),
             "unexpected error message: {msg}"
         );
+    }
+
+    #[test]
+    fn test_verify_hs384_hs512_round_trip_without_exp() {
+        // A validly-signed token that omits `exp` must verify true for every HMAC
+        // algorithm — jsonwebtoken's default required-claims must not reject it.
+        for alg in ["HS256", "HS384", "HS512"] {
+            let secret = "round_trip_secret";
+            let claims = json!({ "sub": "u" }); // no exp claim on purpose
+            let options = EncodeOptions {
+                algorithm: alg,
+                key_data: KeyData::Secret(secret),
+                header_params: None,
+                compress_payload: false,
+            };
+            let token = encode_with_options(&claims, &options)
+                .unwrap_or_else(|e| panic!("encode {alg} failed: {e}"));
+
+            let verify_options = VerifyOptions {
+                key_data: VerifyKeyData::Secret(secret),
+                validate_exp: false,
+                validate_nbf: false,
+                leeway: 0,
+            };
+            let result = verify_with_options(&token, &verify_options);
+            assert!(
+                matches!(result, Ok(true)),
+                "{alg} token without exp should verify true, got {result:?}"
+            );
+
+            // Wrong secret must still fail.
+            let wrong = VerifyOptions {
+                key_data: VerifyKeyData::Secret("nope"),
+                ..Default::default()
+            };
+            assert!(
+                matches!(verify_with_options(&token, &wrong), Ok(false)),
+                "{alg} token must not verify with the wrong secret"
+            );
+        }
     }
 
     #[test]

--- a/src/utils/compression.rs
+++ b/src/utils/compression.rs
@@ -13,13 +13,31 @@ pub fn compress_deflate(data: &[u8]) -> Result<Vec<u8>> {
     Ok(compressed)
 }
 
-/// Decompresses data using DEFLATE decompression algorithm
+/// Maximum number of bytes produced when decompressing an untrusted DEFLATE stream.
+///
+/// DEFLATE can amplify input by more than 1000x, so an unbounded `read_to_end` on
+/// attacker-controlled data is a decompression-bomb / memory-exhaustion vector. The
+/// `zip:"DEF"` payload of any token reaching `jwt::decode` is fully attacker-controlled
+/// (including over the REST server), so the decompressed size must be capped.
+pub const MAX_DECOMPRESSED_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
+
+/// Decompresses data using DEFLATE decompression algorithm.
+///
+/// The decompressed output is capped at [`MAX_DECOMPRESSED_SIZE`]; input that would
+/// expand beyond that limit is rejected with an error instead of being buffered, to
+/// prevent decompression-bomb denial of service from untrusted tokens.
 pub fn decompress_deflate(compressed_data: &[u8]) -> Result<Vec<u8>> {
-    let mut decoder = DeflateDecoder::new(compressed_data);
+    let mut limited = DeflateDecoder::new(compressed_data).take(MAX_DECOMPRESSED_SIZE + 1);
     let mut decompressed = Vec::new();
-    decoder
+    limited
         .read_to_end(&mut decompressed)
         .map_err(|e| anyhow!("Failed to decompress data: {}", e))?;
+    if decompressed.len() as u64 > MAX_DECOMPRESSED_SIZE {
+        return Err(anyhow!(
+            "Decompressed payload exceeds maximum allowed size of {} bytes",
+            MAX_DECOMPRESSED_SIZE
+        ));
+    }
     Ok(decompressed)
 }
 
@@ -64,6 +82,24 @@ mod tests {
         let invalid_data = b"this is not compressed data";
         let result = decompress_deflate(invalid_data);
         assert!(result.is_err(), "Decompressing invalid data should fail");
+    }
+
+    #[test]
+    fn test_decompress_bomb_is_capped() {
+        // A highly compressible input that expands past the cap must be rejected
+        // rather than buffered into memory.
+        let bomb_size = (MAX_DECOMPRESSED_SIZE as usize) + 1024;
+        let compressed = compress_deflate(&vec![0u8; bomb_size]).expect("compress");
+        assert!(
+            compressed.len() < bomb_size,
+            "expected the bomb input to actually compress"
+        );
+        let result = decompress_deflate(&compressed);
+        assert!(
+            result.is_err(),
+            "decompression past the cap must error, got {} bytes",
+            result.map(|v| v.len()).unwrap_or(0)
+        );
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -98,19 +98,62 @@ pub fn format_duration(duration: std::time::Duration) -> String {
     format!("{hours}h {remain_minutes}m {remain_seconds}s")
 }
 
+/// Compares two byte slices in constant time relative to their content.
+///
+/// Returns `false` immediately on a length mismatch (lengths are not secret), but
+/// for equal-length inputs the comparison does not short-circuit on the first
+/// differing byte, avoiding a timing side channel. Used for HMAC signature and
+/// API-key comparisons.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Abbreviates a string to its first `head` and last `tail` characters joined by an
+/// ellipsis. Operates on characters, never raw byte offsets, so multibyte input
+/// (e.g. a pasted token containing non-ASCII bytes) cannot trigger a
+/// non-char-boundary slice panic. Strings short enough to show in full are returned
+/// unchanged.
+pub fn abbreviate_middle(s: &str, head: usize, tail: usize) -> String {
+    if s.chars().count() <= head + tail {
+        return s.to_string();
+    }
+    let prefix: String = s.chars().take(head).collect();
+    let suffix: String = {
+        let mut t: Vec<char> = s.chars().rev().take(tail).collect();
+        t.reverse();
+        t.into_iter().collect()
+    };
+    format!("{prefix}...{suffix}")
+}
+
 /// Formats a base64 encoded string for display with preview (shows first/last chars with length)
+///
+/// Operates on characters rather than raw byte offsets so that JWE/JWK components,
+/// which are not guaranteed to be ASCII (they come unvalidated from attacker-controlled
+/// tokens and remote JWKS endpoints), never trigger a non-char-boundary slice panic.
 pub fn format_base64_preview(base64_str: &str) -> String {
     const PREVIEW_LEN: usize = 8;
 
-    if base64_str.len() <= PREVIEW_LEN * 2 {
+    let char_count = base64_str.chars().count();
+    if char_count <= PREVIEW_LEN * 2 {
         return base64_str.to_string();
     }
 
-    let start = &base64_str[..PREVIEW_LEN];
-    let end = &base64_str[base64_str.len() - PREVIEW_LEN..];
-    let length = base64_str.len();
+    let start: String = base64_str.chars().take(PREVIEW_LEN).collect();
+    let end: String = {
+        let mut tail: Vec<char> = base64_str.chars().rev().take(PREVIEW_LEN).collect();
+        tail.reverse();
+        tail.into_iter().collect()
+    };
 
-    format!("{}...{} ({} chars)", start, end, length)
+    format!("{}...{} ({} chars)", start, end, char_count)
 }
 
 #[cfg(test)]
@@ -225,5 +268,23 @@ mod tests {
         let input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
         let expected = "ABCDEFGH...456789+/ (64 chars)";
         assert_eq!(format_base64_preview(input), expected);
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(b"secret", b"secret"));
+        assert!(!constant_time_eq(b"secret", b"secres"));
+        assert!(!constant_time_eq(b"secret", b"secre"));
+        assert!(!constant_time_eq(b"", b"x"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn test_format_base64_preview_multibyte_no_panic() {
+        // Non-ASCII input must not panic on a non-char-boundary byte slice.
+        let input = "abcdefgé".repeat(4); // multibyte chars straddle the 8-byte preview offsets
+        let preview = format_base64_preview(&input);
+        assert!(preview.contains("..."));
+        assert!(preview.contains("chars)"));
     }
 }


### PR DESCRIPTION
## Summary

A code audit surfaced crash, behavior-mismatch, and DoS/security defects. This PR fixes them (grouped by theme) and adds regression tests.

## Crashes (panics on untrusted/normal input)
- **decode**: out-of-range `exp`/`iat` claims no longer overflow `SystemTime`/chrono — uses `chrono::from_timestamp` on `i64` and skips annotation when out of range.
- **multibyte input** no longer panics on non-char-boundary byte slices in `format_base64_preview`, the shell token previews, the jwks `n` display, and the **interactive shell cursor** (now tracks char boundaries instead of `byte += 1`). Adds shared `utils::abbreviate_middle`.
- **shell**: installs a panic hook in `run_tui` so any panic restores the terminal (no more raw-mode-corrupted session).

## Security / DoS
- **compression**: caps DEFLATE output at 10 MiB to stop a decompression-bomb OOM reachable via the unauthenticated `/decode` endpoint.
- **server**: offloads crack work to `spawn_blocking` and caps the brute-force keyspace so a single request can't pin the Tokio runtime; bounds wordlist reads to regular files under a size limit.
- **verify**: rejects `alg:none` tokens when a key/secret is supplied (CLI + REST); keyless inspection of unsigned tokens still works.
- constant-time comparison for HMAC signatures and the `X-API-KEY` check.

## Behavior mismatches
- **encode**: actually applies custom headers (`kid`/`jku`/`x5u`/`x5c`/…) on the signed, non-compressed path instead of silently dropping them; stops mislabeling an empty-secret HMAC token as "unsigned".
- **mcp**: honors `validate_exp`; rejects brute requests above the length cap instead of silently searching nothing; drops the no-op `concurrency` param.
- **config**: applies `default_secret`/`algorithm`/`wordlist`/`private_key` as fallbacks (CLI flags win) instead of discarding the loaded config.
- **jwks**: emits correct ASN.1 long-form length for content ≥ 65536 bytes.

## Additional bug found while fixing
- **verify**: HS384/HS512/RSA/EC tokens **without** an `exp` claim were wrongly reported invalid because jsonwebtoken's default `Validation` requires `exp`. `create_validation` now clears `required_spec_claims` and disables `aud` validation.

## Cleanup
- Removes unreachable Mcp/Shell launch code in the `--json` branch.
- Replaces tokio runtime `.expect()` with a graceful error exit.
- Serializes the shell's global stdout/stderr capture to avoid an output race.

## Verification
- `cargo test`: 313 + 105 pass, 0 fail (regression tests added)
- `cargo clippy --all-targets`: no warnings
- `cargo build --release` (panic=abort + LTO): compiles

## Deferred (needs a product decision)
Targeted-field cracking (`--target-field`) re-signs candidates with an empty secret and compares signatures, which can't match a real-secret token by design. The header-dropping root cause is fixed here, but the signature-matching approach itself (emit candidate tokens vs. require the secret) is left for a follow-up.