### PR TITLE
feat: wordlist presets, comprehensive tests, benchmarks & fuzzing (#80, #180, #184)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,40 @@
+---
+name: Benchmarks
+on:
+  push:
+    branches: [main]
+    paths: ["**/*.rs", Cargo.toml, "benches/**"]
+  pull_request:
+    branches: [main]
+    paths: ["**/*.rs", Cargo.toml, "benches/**"]
+  workflow_dispatch:
+permissions:
+  contents: write
+  deployments: write
+  pull-requests: write
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  benchmark:
+    name: Criterion benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run benchmarks
+        run: cargo bench --bench jwt_benchmarks -- --output-format bencher | tee output.txt
+      - name: Store benchmark result & compare against baseline
+        uses: benchmark-action/github-action-benchmark@v1
+        continue-on-error: true
+        with:
+          name: jwt-hack benchmarks
+          tool: cargo
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Publish the baseline only from main; PRs compare against it read-only.
+          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          comment-on-alert: true
+          summary-always: true
+          # Flag >200% regressions in a PR comment, but never fail the job.
+          alert-threshold: "200%"
+          fail-on-alert: false

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,33 @@
+---
+name: Fuzz
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly short fuzzing run (Mondays 04:00 UTC).
+    - cron: "0 4 * * 1"
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  fuzz:
+    name: cargo-fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [jwt_decode, jwe_decode, header_parsing]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+      - name: Run fuzz target (time-boxed)
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=120
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@
 *.swo
 
 docs/public
+
+# cargo-fuzz build artifacts and generated corpora
+/fuzz/target/
+/fuzz/corpus/
+/fuzz/artifacts/
+/fuzz/coverage/
+/fuzz/Cargo.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ Always reference these instructions first and fallback to search or bash command
 - Format check: `cargo fmt --check`
 - Format code: `just fix` or `cargo fmt`
 
+### Benchmarks and Fuzzing
+- Run performance benchmarks (criterion): `just bench` or `cargo bench`
+  - Covers encode, decode, verify, and cracking (dictionary + brute force).
+  - CI tracks results against a baseline via `.github/workflows/benchmarks.yml`.
+- Run a fuzz target (requires nightly + `cargo install cargo-fuzz`):
+  - `just fuzz jwt_decode` (or `jwe_decode`, `header_parsing`)
+  - `cargo +nightly fuzz run <target> -- -max_total_time=60`
+  - Fuzz targets live in `fuzz/fuzz_targets/`; scheduled/manual CI is in `.github/workflows/fuzz.yml`.
+
 ### Development Tasks
 - List available Just commands: `just --list`
 - Format and fix linting: `just fix`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi-to-tui"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +381,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -541,6 +580,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +672,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1130,6 +1211,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1257,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1487,10 +1585,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1649,6 +1767,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "criterion",
  "crossterm",
  "dirs",
  "env_logger",
@@ -2004,6 +2123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2409,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,7 +2667,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -2579,7 +2732,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -3487,6 +3640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,7 +3883,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ num-bigint = "0.4"
 zeroize = "1.8.2"
 mimalloc = { version = "0.1", default-features = false }
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
 [profile.release]
 opt-level = 3
 lto = true
@@ -61,3 +64,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "jwt-hack"
 path = "src/main.rs"
+
+[[bench]]
+name = "jwt_benchmarks"
+harness = false

--- a/benches/jwt_benchmarks.rs
+++ b/benches/jwt_benchmarks.rs
@@ -1,0 +1,120 @@
+//! Criterion performance benchmarks for jwt-hack's core operations.
+//!
+//! Covers the operations called out in issue #184: encode, decode, verify, and
+//! cracking (dictionary + brute force). Run with `cargo bench`.
+
+use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use jwt_hack::crack::brute;
+use jwt_hack::jwt::{self, EncodeOptions, KeyData};
+use serde_json::json;
+
+fn sample_claims() -> serde_json::Value {
+    json!({
+        "sub": "1234567890",
+        "name": "John Doe",
+        "iat": 1_516_239_022,
+        "role": "admin",
+        "scope": "read write"
+    })
+}
+
+fn bench_encode(c: &mut Criterion) {
+    let claims = sample_claims();
+    c.bench_function("encode_hs256", |b| {
+        b.iter(|| jwt::encode(black_box(&claims), black_box("secret"), "HS256").unwrap())
+    });
+
+    let claims_c = sample_claims();
+    c.bench_function("encode_hs256_compressed", |b| {
+        let options = EncodeOptions {
+            algorithm: "HS256",
+            key_data: KeyData::Secret("secret"),
+            header_params: None,
+            compress_payload: true,
+        };
+        b.iter(|| jwt::encode_with_options(black_box(&claims_c), &options).unwrap())
+    });
+}
+
+fn bench_decode(c: &mut Criterion) {
+    let token = jwt::encode(&sample_claims(), "secret", "HS256").unwrap();
+    c.bench_function("decode", |b| {
+        b.iter(|| jwt::decode(black_box(&token)).unwrap())
+    });
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let token = jwt::encode(&sample_claims(), "secret", "HS256").unwrap();
+
+    c.bench_function("verify_hs256", |b| {
+        b.iter(|| jwt::verify(black_box(&token), black_box("secret")).unwrap())
+    });
+
+    // The reusable fast-path verifier used inside the crack hot loop.
+    let verifier = jwt::prepare_hs256_verifier(&token).unwrap();
+    c.bench_function("verify_hs256_fastpath", |b| {
+        b.iter(|| black_box(verifier.verify(black_box(b"secret"))))
+    });
+}
+
+fn bench_crack_dict(c: &mut Criterion) {
+    let token = jwt::encode(&sample_claims(), "letmein", "HS256").unwrap();
+    let wordlist = [
+        "password", "123456", "admin", "root", "qwerty", "secret", "dragon", "letmein",
+    ];
+    let verifier = jwt::prepare_hs256_verifier(&token).unwrap();
+
+    c.bench_function("crack_dict_8_words", |b| {
+        b.iter(|| {
+            black_box(
+                wordlist
+                    .iter()
+                    .find(|w| verifier.verify(w.as_bytes()))
+                    .copied(),
+            )
+        })
+    });
+}
+
+fn bench_crack_brute(c: &mut Criterion) {
+    // Worst-case: the secret is the last 3-char lowercase candidate ("zzz"), so
+    // the loop enumerates the full 26^3 keyspace before finding it.
+    let token = jwt::encode(&sample_claims(), "zzz", "HS256").unwrap();
+    let verifier = jwt::prepare_hs256_verifier(&token).unwrap();
+    let char_bytes = brute::charset_bytes("abcdefghijklmnopqrstuvwxyz");
+    let length = 3usize;
+    let total = (char_bytes.len() as u64).pow(length as u32);
+
+    c.bench_function("crack_brute_len3_lower", |b| {
+        b.iter(|| {
+            let mut buf = Vec::with_capacity(length);
+            let mut found = None;
+            for idx in 0..total {
+                brute::write_candidate_bytes(idx, &char_bytes, length, &mut buf);
+                if verifier.verify(&buf) {
+                    found = Some(idx);
+                    break;
+                }
+            }
+            black_box(found)
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    // Keep CI wall-clock bounded while still statistically meaningful.
+    config = Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(3));
+    targets =
+        bench_encode,
+        bench_decode,
+        bench_verify,
+        bench_crack_dict,
+        bench_crack_brute
+}
+criterion_main!(benches);

--- a/docs/content/usage/commands/crack.md
+++ b/docs/content/usage/commands/crack.md
@@ -23,6 +23,30 @@ jwt-hack crack -w wordlist.txt <TOKEN>
 jwt-hack crack --wordlist=/path/to/custom/wordlist.txt <TOKEN>
 ```
 
+### Preset Wordlists
+
+Instead of managing wordlist files yourself, use a numbered preset. The wordlist
+is downloaded once into the config directory (`<config>/jwt-hack/wordlists/`) and
+reused on subsequent runs. A checksum sidecar is stored alongside each download,
+so a cached copy with a matching hash is served straight from disk — the
+download is skipped.
+
+```bash
+# Download (first run) and use the raft-medium-words wordlist
+jwt-hack crack -p 1 <TOKEN>
+
+# Long form
+jwt-hack crack --wordlist-preset 2 <TOKEN>
+```
+
+Available presets:
+
+| Preset | Name              | Source                                   |
+|--------|-------------------|------------------------------------------|
+| `1`    | raft-medium-words | SecLists (medium web-content wordlist)   |
+| `2`    | raft-large-words  | SecLists (large web-content wordlist)    |
+| `3`    | jwt-secrets       | Wallarm jwt-secrets (common JWT secrets) |
+
 ## Brute Force Attack
 
 Generate and test password combinations:
@@ -95,6 +119,7 @@ jwt-hack crack -w wordlist.txt <TOKEN> --verbose
 
 ### Attack Mode Options
 - `-w, --wordlist <FILE>` - Path to wordlist file
+- `-p, --wordlist-preset <ID>` - Download & use a preset wordlist (1=raft-medium-words, 2=raft-large-words, 3=jwt-secrets)
 - `-m, --mode <MODE>` - Attack mode: dictionary (default) or brute
 
 ### Performance Options

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "jwt-hack-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.jwt-hack]
+path = ".."
+
+# Prevent this crate from being pulled into (or pulling in) the parent package;
+# cargo-fuzz builds it as its own standalone workspace on nightly.
+[workspace]
+
+[[bin]]
+name = "jwt_decode"
+path = "fuzz_targets/jwt_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "jwe_decode"
+path = "fuzz_targets/jwe_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "header_parsing"
+path = "fuzz_targets/header_parsing.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/header_parsing.rs
+++ b/fuzz/fuzz_targets/header_parsing.rs
@@ -1,0 +1,15 @@
+#![no_main]
+//! Fuzz target focused on JWT header parsing. Treats the input as the first
+//! (header) segment of an otherwise well-formed token, forcing `decode` through
+//! the base64/JSON header parser with arbitrary bytes.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(header_segment) = std::str::from_utf8(data) {
+        // Minimal payload "{}" -> "e30", empty signature.
+        let token = format!("{header_segment}.e30.");
+        let _ = jwt_hack::jwt::detect_token_type(&token);
+        let _ = jwt_hack::jwt::decode(&token);
+    }
+});

--- a/fuzz/fuzz_targets/jwe_decode.rs
+++ b/fuzz/fuzz_targets/jwe_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+//! Fuzz target for JWE parsing/decryption. Exercises `decode_jwe` (structural
+//! parsing of the 5-part JWE) and `decrypt_jwe` (the candidate-key path used by
+//! cracking), asserting only that neither panics on malformed input.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = jwt_hack::jwt::decode_jwe(s);
+        // A fixed 32-byte candidate key drives the direct-decryption path.
+        let _ = jwt_hack::jwt::decrypt_jwe(s, "0123456789abcdef0123456789abcdef");
+    }
+});

--- a/fuzz/fuzz_targets/jwt_decode.rs
+++ b/fuzz/fuzz_targets/jwt_decode.rs
@@ -1,0 +1,12 @@
+#![no_main]
+//! Fuzz target for JWT decoding. Feeds arbitrary UTF-8 into `jwt::decode` and
+//! `detect_token_type`, asserting only that they never panic on malformed input.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = jwt_hack::jwt::detect_token_type(s);
+        let _ = jwt_hack::jwt::decode(s);
+    }
+});

--- a/justfile
+++ b/justfile
@@ -53,3 +53,13 @@ test:
     cargo clippy --tests -- --deny warnings
     cargo fmt --check
     cargo doc --workspace --all-features --no-deps --document-private-items
+
+# Run criterion performance benchmarks.
+[group('test')]
+bench:
+    cargo bench
+
+# Run a cargo-fuzz target (requires nightly + cargo-fuzz). Usage: just fuzz jwt_decode
+[group('test')]
+fuzz target="jwt_decode" time="60":
+    cargo +nightly fuzz run {{target}} -- -max_total_time={{time}}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -111,6 +111,12 @@ pub enum Commands {
         #[arg(short, long)]
         wordlist: Option<PathBuf>,
 
+        /// Download & use a numbered preset wordlist for dictionary attacks
+        /// (1=raft-medium-words, 2=raft-large-words, 3=jwt-secrets). Cached under
+        /// the config dir; re-download is skipped when the cached copy matches.
+        #[arg(short = 'p', long = "wordlist-preset")]
+        wordlist_preset: Option<u32>,
+
         /// Character list (for bruteforce attack)
         #[arg(long, default_value = "abcdefghijklmnopqrstuvwxyz0123456789")]
         chars: String,
@@ -287,6 +293,24 @@ pub enum JwksAction {
     },
 }
 
+/// Resolve the effective wordlist for a crack invocation.
+///
+/// Precedence: a `--wordlist-preset` wins (downloading/caching the preset on
+/// demand), then an explicit `--wordlist`, then the configured default wordlist.
+fn resolve_crack_wordlist(
+    wordlist: &Option<PathBuf>,
+    wordlist_preset: Option<u32>,
+    config_default: &Option<PathBuf>,
+) -> anyhow::Result<Option<PathBuf>> {
+    if let Some(id) = wordlist_preset {
+        return Ok(Some(crate::crack::wordlist_preset::ensure_wordlist(id)?));
+    }
+    if wordlist.is_some() {
+        return Ok(wordlist.clone());
+    }
+    Ok(config_default.clone())
+}
+
 /// Parses command-line arguments and executes the appropriate command
 pub fn execute() {
     let cli = Cli::parse();
@@ -344,6 +368,7 @@ pub fn execute() {
                 token,
                 mode,
                 wordlist,
+                wordlist_preset,
                 chars,
                 preset,
                 concurrency,
@@ -354,25 +379,23 @@ pub fn execute() {
                 target_field,
                 pattern,
             }) => {
-                let wordlist = if wordlist.is_some() {
-                    wordlist
-                } else {
-                    &config.default_wordlist
-                };
-                crack::execute_json(
-                    token,
-                    mode,
-                    wordlist,
-                    chars,
-                    preset,
-                    *concurrency,
-                    *min,
-                    *max,
-                    *power,
-                    *verbose,
-                    target_field,
-                    pattern,
-                )
+                match resolve_crack_wordlist(wordlist, *wordlist_preset, &config.default_wordlist) {
+                    Ok(effective_wordlist) => crack::execute_json(
+                        token,
+                        mode,
+                        &effective_wordlist,
+                        chars,
+                        preset,
+                        *concurrency,
+                        *min,
+                        *max,
+                        *power,
+                        *verbose,
+                        target_field,
+                        pattern,
+                    ),
+                    Err(e) => Err(e),
+                }
             }
             Some(Commands::Payload {
                 token,
@@ -513,6 +536,7 @@ pub fn execute() {
             token,
             mode,
             wordlist,
+            wordlist_preset,
             chars,
             preset,
             concurrency,
@@ -523,15 +547,21 @@ pub fn execute() {
             target_field,
             pattern,
         }) => {
-            let wordlist = if wordlist.is_some() {
-                wordlist
-            } else {
-                &config.default_wordlist
+            let effective_wordlist = match resolve_crack_wordlist(
+                wordlist,
+                *wordlist_preset,
+                &config.default_wordlist,
+            ) {
+                Ok(w) => w,
+                Err(e) => {
+                    error!("Failed to resolve wordlist preset: {e}");
+                    std::process::exit(1);
+                }
             };
             crack::execute(
                 token,
                 mode,
-                wordlist,
+                &effective_wordlist,
                 chars,
                 preset,
                 *concurrency,
@@ -699,6 +729,46 @@ mod tests {
         let cli = Cli::try_parse_from(["jwt-hack", "decode", "--json", "a.b.c"]).expect("parse ok");
         assert!(cli.output_json);
         assert!(matches!(cli.command, Some(Commands::Decode { .. })));
+    }
+
+    #[test]
+    fn test_cli_parses_crack_wordlist_preset() {
+        let cli = Cli::try_parse_from(["jwt-hack", "crack", "-p", "1", "a.b.c"]).expect("parse ok");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Crack {
+                wordlist_preset: Some(1),
+                ..
+            })
+        ));
+
+        let cli = Cli::try_parse_from(["jwt-hack", "crack", "--wordlist-preset", "2", "a.b.c"])
+            .expect("parse ok");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Crack {
+                wordlist_preset: Some(2),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_resolve_crack_wordlist_precedence() {
+        let explicit = Some(PathBuf::from("/tmp/explicit.txt"));
+        let default = Some(PathBuf::from("/tmp/default.txt"));
+
+        // Explicit wordlist is used when no preset is requested.
+        let resolved = resolve_crack_wordlist(&explicit, None, &default).unwrap();
+        assert_eq!(resolved, explicit);
+
+        // Falls back to the configured default when neither is given.
+        let resolved = resolve_crack_wordlist(&None, None, &default).unwrap();
+        assert_eq!(resolved, default);
+
+        // No wordlist at all resolves to None.
+        let resolved = resolve_crack_wordlist(&None, None, &None).unwrap();
+        assert_eq!(resolved, None);
     }
 
     #[test]

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -760,6 +760,7 @@ pub async fn execute_with_api_key(host: &str, port: u16, api_key: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_default_crack_mode() {
@@ -965,5 +966,233 @@ mod tests {
         let resp = handle_crack(Json(req)).await.unwrap().0;
         assert!(resp.success);
         assert_eq!(resp.secret.as_deref(), Some("letmein"));
+    }
+
+    // ---- Router-level endpoint tests (mock HTTP requests through build_router) ----
+
+    /// Drive a mock request through the full router and return (status, json body).
+    async fn call_router(
+        app: &mut Router,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::Service;
+
+        let builder = Request::builder().method(method).uri(uri);
+        let req = match body {
+            Some(b) => builder
+                .header("content-type", "application/json")
+                .body(Body::from(b.to_string()))
+                .unwrap(),
+            None => builder.body(Body::empty()).unwrap(),
+        };
+
+        let res = Service::call(app, req).await.unwrap();
+        let status = res.status();
+        let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, json)
+    }
+
+    #[tokio::test]
+    async fn test_router_health_endpoint() {
+        let mut app = build_router(None);
+        let (status, body) = call_router(&mut app, "GET", "/health", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_router_decode_endpoint() {
+        let mut app = build_router(None);
+        let token = jwt::encode(
+            &serde_json::json!({"sub": "1234", "name": "Jane"}),
+            "s",
+            "HS256",
+        )
+        .unwrap();
+        let (status, body) =
+            call_router(&mut app, "POST", "/decode", Some(json!({"token": token}))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["success"], true);
+        assert_eq!(body["payload"]["name"], "Jane");
+    }
+
+    #[tokio::test]
+    async fn test_router_encode_then_verify_roundtrip() {
+        let mut app = build_router(None);
+
+        // Encode
+        let (status, body) = call_router(
+            &mut app,
+            "POST",
+            "/encode",
+            Some(json!({"payload": {"sub": "abc"}, "secret": "topsecret", "algorithm": "HS256"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["success"], true);
+        let token = body["token"].as_str().expect("token").to_string();
+
+        // Verify (correct secret)
+        let (status, body) = call_router(
+            &mut app,
+            "POST",
+            "/verify",
+            Some(json!({"token": token, "secret": "topsecret"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], true);
+
+        // Verify (wrong secret)
+        let (_status, body) = call_router(
+            &mut app,
+            "POST",
+            "/verify",
+            Some(json!({"token": token, "secret": "nope"})),
+        )
+        .await;
+        assert_eq!(body["valid"], false);
+    }
+
+    #[tokio::test]
+    async fn test_router_crack_brute_endpoint() {
+        let mut app = build_router(None);
+        let token = jwt::encode(&serde_json::json!({"sub": "x"}), "ab", "HS256").unwrap();
+        let (status, body) = call_router(
+            &mut app,
+            "POST",
+            "/crack",
+            Some(json!({"token": token, "mode": "brute", "chars": "ab", "min": 1, "max": 3})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["success"], true);
+        assert_eq!(body["secret"], "ab");
+    }
+
+    #[tokio::test]
+    async fn test_router_crack_dict_inline_endpoint() {
+        let mut app = build_router(None);
+        let token = jwt::encode(&serde_json::json!({"sub": "x"}), "hunter2", "HS256").unwrap();
+        let (status, body) = call_router(
+            &mut app,
+            "POST",
+            "/crack",
+            Some(json!({
+                "token": token,
+                "mode": "dict",
+                "wordlist_content": ["foo", "hunter2", "bar"]
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["secret"], "hunter2");
+    }
+
+    #[tokio::test]
+    async fn test_router_payload_endpoint() {
+        let mut app = build_router(None);
+        let token = jwt::encode(&serde_json::json!({"sub": "x"}), "s", "HS256").unwrap();
+        let (status, body) = call_router(
+            &mut app,
+            "POST",
+            "/payload",
+            Some(json!({"token": token, "target": "none"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["success"], true);
+        assert!(
+            body["payloads"]
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false),
+            "expected at least one payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_router_scan_endpoint_finds_weak_secret() {
+        let mut app = build_router(None);
+        let token = jwt::encode(&serde_json::json!({"sub": "x"}), "test", "HS256").unwrap();
+        let (status, body) = call_router(
+            &mut app,
+            "POST",
+            "/scan",
+            Some(json!({
+                "token": token,
+                "skip_payloads": true,
+                "wordlist_content": ["nope", "test"]
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["success"], true);
+        assert_eq!(body["secret"], "test");
+    }
+
+    #[tokio::test]
+    async fn test_router_unknown_route_is_404() {
+        let mut app = build_router(None);
+        let (status, _body) =
+            call_router(&mut app, "POST", "/does-not-exist", Some(json!({}))).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_router_invalid_json_is_client_error() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::Service;
+
+        let mut app = build_router(None);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/decode")
+            .header("content-type", "application/json")
+            .body(Body::from("this is not json"))
+            .unwrap();
+        let res = Service::call(&mut app, req).await.unwrap();
+        assert!(
+            res.status().is_client_error(),
+            "malformed JSON should yield a 4xx, got {}",
+            res.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_router_api_key_gates_endpoints() {
+        let mut app = build_router(Some("secret-key".to_string()));
+
+        // Without the key, a normal endpoint is rejected.
+        let (status, _b) =
+            call_router(&mut app, "POST", "/decode", Some(json!({"token": "a.b.c"}))).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+        // With the key, the request is processed.
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::Service;
+        let token = jwt::encode(&serde_json::json!({"sub": "x"}), "s", "HS256").unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/decode")
+            .header("content-type", "application/json")
+            .header("X-API-KEY", "secret-key")
+            .body(Body::from(json!({"token": token}).to_string()))
+            .unwrap();
+        let res = Service::call(&mut app, req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
     }
 }

--- a/src/cmd/shell/mod.rs
+++ b/src/cmd/shell/mod.rs
@@ -1006,4 +1006,109 @@ mod tests {
         app.push_warning("warn");
         assert_eq!(app.output_lines.lines.len(), 3);
     }
+
+    // ---- Command execution tests ----
+
+    #[test]
+    fn test_handle_command_encode_runs() {
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command("set secret shellsecret", &mut app, &tx);
+        let before = app.output_lines.lines.len();
+        handle_command("encode {\"sub\":\"1\"}", &mut app, &tx);
+        assert!(!app.should_quit);
+        // Encoding should not mutate session state and should produce output.
+        assert_eq!(app.session.secret.as_deref(), Some("shellsecret"));
+        assert!(app.output_lines.lines.len() > before);
+    }
+
+    #[test]
+    fn test_handle_command_encode_missing_json_errors() {
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command("encode", &mut app, &tx);
+        assert!(!app.should_quit);
+        assert!(!app.output_lines.lines.is_empty());
+    }
+
+    #[test]
+    fn test_handle_command_verify_runs() {
+        // Build a real token so the verify path exercises signature checking.
+        let token = crate::jwt::encode(&serde_json::json!({"sub": "1"}), "shellsecret", "HS256")
+            .expect("encode token");
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command(&format!("set token {token}"), &mut app, &tx);
+        handle_command("set secret shellsecret", &mut app, &tx);
+        let before = app.output_lines.lines.len();
+        handle_command("verify", &mut app, &tx);
+        assert!(!app.should_quit);
+        assert!(app.output_lines.lines.len() > before);
+    }
+
+    #[test]
+    fn test_handle_command_verify_no_token_errors() {
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command("verify", &mut app, &tx);
+        assert!(!app.output_lines.lines.is_empty());
+    }
+
+    #[test]
+    fn test_handle_command_payload_runs() {
+        let token = crate::jwt::encode(&serde_json::json!({"sub": "1"}), "s", "HS256")
+            .expect("encode token");
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command(&format!("payload {token}"), &mut app, &tx);
+        assert!(!app.should_quit);
+        assert!(!app.output_lines.lines.is_empty());
+    }
+
+    #[test]
+    fn test_handle_command_crack_no_token_errors() {
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command("crack", &mut app, &tx);
+        assert!(!app.should_quit);
+        assert!(!app.output_lines.lines.is_empty());
+    }
+
+    #[test]
+    fn test_handle_command_crack_with_token_starts_background() {
+        let token = crate::jwt::encode(&serde_json::json!({"sub": "1"}), "s", "HS256")
+            .expect("encode token");
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command(&format!("crack {token}"), &mut app, &tx);
+        // Should not block or quit; a background message is shown immediately.
+        assert!(!app.should_quit);
+        assert!(!app.output_lines.lines.is_empty());
+    }
+
+    #[test]
+    fn test_handle_command_scan_with_token_starts_background() {
+        let token = crate::jwt::encode(&serde_json::json!({"sub": "1"}), "s", "HS256")
+            .expect("encode token");
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command(&format!("scan {token}"), &mut app, &tx);
+        assert!(!app.should_quit);
+        assert!(!app.output_lines.lines.is_empty());
+    }
+
+    #[test]
+    fn test_full_workflow_set_and_show() {
+        let mut app = App::new();
+        let (tx, _rx) = mpsc::channel();
+        handle_command("set algorithm RS256", &mut app, &tx);
+        handle_command("set token a.b.c", &mut app, &tx);
+        handle_command("set secret sekret", &mut app, &tx);
+        handle_command("show", &mut app, &tx);
+
+        assert_eq!(app.session.algorithm, "RS256");
+        assert_eq!(app.session.token.as_deref(), Some("a.b.c"));
+        assert_eq!(app.session.secret.as_deref(), Some("sekret"));
+        assert_eq!(app.session.prompt(), "jwt-hack(RS256)[JWT]> ");
+    }
 }

--- a/src/crack/mod.rs
+++ b/src/crack/mod.rs
@@ -1,4 +1,5 @@
 pub mod brute;
+pub mod wordlist_preset;
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;

--- a/src/crack/wordlist_preset.rs
+++ b/src/crack/wordlist_preset.rs
@@ -1,0 +1,323 @@
+//! Downloadable, cacheable wordlist presets for dictionary cracking.
+//!
+//! `jwt-hack crack -p <id>` (a.k.a. `--wordlist-preset <id>`) resolves a numeric
+//! preset to a well-known wordlist, downloading it into the tool's config
+//! directory on first use. Subsequent runs reuse the cached copy: a checksum
+//! sidecar is written alongside each download so an existing file with a
+//! matching hash is served straight from disk instead of being re-downloaded.
+
+use anyhow::{anyhow, Context, Result};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::config::Config;
+
+/// A downloadable wordlist identified by a numeric preset id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WordlistPreset {
+    /// Numeric id used on the command line (`-p <id>`).
+    pub id: u32,
+    /// Short, filesystem-friendly name (also the cached file stem).
+    pub name: &'static str,
+    /// Remote URL the wordlist is downloaded from.
+    pub url: &'static str,
+    /// Human-readable description shown in help/errors.
+    pub description: &'static str,
+}
+
+/// Built-in wordlist presets. `jwt-hack crack -p <id>` downloads and caches these.
+pub const PRESETS: &[WordlistPreset] = &[
+    WordlistPreset {
+        id: 1,
+        name: "raft-medium-words",
+        url: "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/raft-medium-words.txt",
+        description: "SecLists raft-medium-words (medium web-content wordlist)",
+    },
+    WordlistPreset {
+        id: 2,
+        name: "raft-large-words",
+        url: "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/raft-large-words.txt",
+        description: "SecLists raft-large-words (large web-content wordlist)",
+    },
+    WordlistPreset {
+        id: 3,
+        name: "jwt-secrets",
+        url: "https://raw.githubusercontent.com/wallarm/jwt-secrets/master/jwt.secrets.list",
+        description: "Wallarm jwt-secrets (common JWT signing secrets)",
+    },
+];
+
+/// Look up a preset by its numeric id.
+pub fn get_preset(id: u32) -> Option<&'static WordlistPreset> {
+    PRESETS.iter().find(|p| p.id == id)
+}
+
+/// Human-readable list of available presets for help/error messages.
+pub fn preset_list_string() -> String {
+    PRESETS
+        .iter()
+        .map(|p| format!("  {} = {} ({})", p.id, p.name, p.description))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Directory where downloaded preset wordlists are cached
+/// (`<config dir>/wordlists`).
+pub fn cache_dir() -> Option<PathBuf> {
+    Config::default_config_dir().map(|d| d.join("wordlists"))
+}
+
+/// Lowercase hex SHA-256 digest of `bytes`.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = hmac_sha256::Hash::hash(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        // Writing to a String is infallible.
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Path of the cached wordlist file for a preset.
+fn wordlist_file(dir: &Path, preset: &WordlistPreset) -> PathBuf {
+    dir.join(format!("{}.txt", preset.name))
+}
+
+/// Path of the checksum sidecar for a preset's cached wordlist.
+fn sha_sidecar(dir: &Path, preset: &WordlistPreset) -> PathBuf {
+    dir.join(format!("{}.txt.sha256", preset.name))
+}
+
+/// True when a cached copy exists whose contents hash matches the stored sidecar.
+///
+/// This is what lets us "skip downloading a file with the same hash": the sidecar
+/// records the hash of the bytes we last wrote, and we only trust the cache when
+/// the file still hashes to that value (guarding against truncated/edited files).
+fn cached_and_valid(dir: &Path, preset: &WordlistPreset) -> bool {
+    let file = wordlist_file(dir, preset);
+    let sidecar = sha_sidecar(dir, preset);
+    let (Ok(content), Ok(expected)) = (fs::read(&file), fs::read_to_string(&sidecar)) else {
+        return false;
+    };
+    !content.is_empty() && sha256_hex(&content) == expected.trim()
+}
+
+/// Resolve a preset wordlist into a local path, using `dir` as the cache and
+/// `download` to fetch bytes when a valid cached copy is not present.
+///
+/// This is the testable core of [`ensure_wordlist`]: callers inject the cache
+/// directory and the network fetch so the caching / integrity logic can be
+/// exercised without touching the real config dir or the network.
+pub fn ensure_wordlist_in<F>(preset: &WordlistPreset, dir: &Path, download: F) -> Result<PathBuf>
+where
+    F: FnOnce(&str) -> Result<Vec<u8>>,
+{
+    let file = wordlist_file(dir, preset);
+
+    // A byte-identical cached copy already exists -> skip the download entirely.
+    if cached_and_valid(dir, preset) {
+        return Ok(file);
+    }
+
+    fs::create_dir_all(dir)
+        .with_context(|| format!("Failed to create wordlist cache dir: {}", dir.display()))?;
+
+    let bytes = download(preset.url)
+        .with_context(|| format!("Failed to download preset wordlist from {}", preset.url))?;
+    if bytes.is_empty() {
+        return Err(anyhow!("downloaded wordlist '{}' is empty", preset.name));
+    }
+
+    fs::write(&file, &bytes)
+        .with_context(|| format!("Failed to write wordlist file: {}", file.display()))?;
+    fs::write(sha_sidecar(dir, preset), sha256_hex(&bytes))
+        .context("Failed to write wordlist checksum sidecar")?;
+
+    Ok(file)
+}
+
+/// Blocking HTTP(S) download used by the real [`ensure_wordlist`] path.
+fn http_download(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()?;
+    let response = client
+        .get(url)
+        .header(
+            "User-Agent",
+            concat!("jwt-hack/", env!("CARGO_PKG_VERSION")),
+        )
+        .send()
+        .map_err(|e| anyhow!("request to {url} failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "download from {url} returned status {}",
+            response.status()
+        ));
+    }
+    Ok(response.bytes()?.to_vec())
+}
+
+/// Resolve a numeric preset id into a local wordlist path, downloading and
+/// caching it under the config directory on first use.
+pub fn ensure_wordlist(id: u32) -> Result<PathBuf> {
+    let preset = get_preset(id).ok_or_else(|| {
+        anyhow!(
+            "unknown wordlist preset '{id}'. Available presets:\n{}",
+            preset_list_string()
+        )
+    })?;
+    let dir = cache_dir()
+        .ok_or_else(|| anyhow!("could not determine a config directory for the wordlist cache"))?;
+
+    let file = wordlist_file(&dir, preset);
+    if cached_and_valid(&dir, preset) {
+        crate::utils::log_info(format!(
+            "Using cached preset wordlist '{}' ({})",
+            preset.name,
+            file.display()
+        ));
+        return Ok(file);
+    }
+
+    crate::utils::log_info(format!(
+        "Downloading preset wordlist '{}' from {}",
+        preset.name, preset.url
+    ));
+    let path = ensure_wordlist_in(preset, &dir, http_download)?;
+    crate::utils::log_success(format!(
+        "Preset wordlist '{}' ready ({})",
+        preset.name,
+        path.display()
+    ));
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_get_preset_known_and_unknown() {
+        assert_eq!(get_preset(1).unwrap().name, "raft-medium-words");
+        assert_eq!(get_preset(2).unwrap().name, "raft-large-words");
+        assert_eq!(get_preset(3).unwrap().name, "jwt-secrets");
+        assert!(get_preset(0).is_none());
+        assert!(get_preset(999).is_none());
+    }
+
+    #[test]
+    fn test_preset_ids_are_unique() {
+        let mut ids: Vec<u32> = PRESETS.iter().map(|p| p.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), PRESETS.len(), "preset ids must be unique");
+    }
+
+    #[test]
+    fn test_preset_list_string_mentions_all() {
+        let list = preset_list_string();
+        for p in PRESETS {
+            assert!(list.contains(p.name), "list should mention {}", p.name);
+        }
+    }
+
+    #[test]
+    fn test_sha256_hex_known_vector() {
+        // Empty input has a well-known SHA-256 digest.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn test_ensure_wordlist_downloads_then_caches() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("wordlists");
+        let preset = get_preset(1).unwrap();
+
+        let calls = Cell::new(0);
+        let downloader = |_url: &str| -> Result<Vec<u8>> {
+            calls.set(calls.get() + 1);
+            Ok(b"secret\npassword\nletmein\n".to_vec())
+        };
+
+        // First call downloads and writes the cache + sidecar.
+        let path = ensure_wordlist_in(preset, &dir, downloader).unwrap();
+        assert!(path.exists());
+        assert_eq!(calls.get(), 1);
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("letmein"));
+        assert!(sha_sidecar(&dir, preset).exists());
+
+        // Second call reuses the cache and does NOT invoke the downloader.
+        let path2 = ensure_wordlist_in(preset, &dir, |_url| {
+            calls.set(calls.get() + 1);
+            Ok(b"SHOULD-NOT-BE-CALLED".to_vec())
+        })
+        .unwrap();
+        assert_eq!(path, path2);
+        assert_eq!(calls.get(), 1, "cached copy must skip re-download");
+    }
+
+    #[test]
+    fn test_ensure_wordlist_redownloads_on_hash_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("wordlists");
+        let preset = get_preset(2).unwrap();
+
+        // Seed a cache file whose contents do not match its sidecar hash.
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(wordlist_file(&dir, preset), b"stale-content").unwrap();
+        fs::write(sha_sidecar(&dir, preset), sha256_hex(b"different")).unwrap();
+        assert!(!cached_and_valid(&dir, preset));
+
+        let downloaded = Cell::new(false);
+        let path = ensure_wordlist_in(preset, &dir, |_url| {
+            downloaded.set(true);
+            Ok(b"fresh\ncontent\n".to_vec())
+        })
+        .unwrap();
+
+        assert!(downloaded.get(), "hash mismatch must force a re-download");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "fresh\ncontent\n");
+        assert!(cached_and_valid(&dir, preset));
+    }
+
+    #[test]
+    fn test_ensure_wordlist_rejects_empty_download() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("wordlists");
+        let preset = get_preset(1).unwrap();
+
+        let result = ensure_wordlist_in(preset, &dir, |_url| Ok(Vec::new()));
+        assert!(result.is_err(), "empty downloads should be rejected");
+    }
+
+    #[test]
+    fn test_ensure_wordlist_propagates_download_error() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("wordlists");
+        let preset = get_preset(1).unwrap();
+
+        let result = ensure_wordlist_in(preset, &dir, |_url| Err(anyhow!("network down")));
+        assert!(result.is_err());
+        // Nothing should have been cached.
+        assert!(!wordlist_file(&dir, preset).exists());
+    }
+
+    #[test]
+    fn test_ensure_wordlist_unknown_id_errors() {
+        let err = ensure_wordlist(9999).unwrap_err().to_string();
+        assert!(err.contains("unknown wordlist preset"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod crack;
 pub mod jwe_attacks;
 pub mod jwks;
 pub mod jwt;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,147 @@
+//! End-to-end workflow tests exercising full jwt-hack lifecycles through the
+//! public library API: encode -> crack -> verify, plus compression and JWE
+//! round-trips. These use only `jwt_hack::*` so they mirror what a downstream
+//! integrator (or the CLI) actually drives.
+
+use jwt_hack::crack::brute;
+use jwt_hack::jwt::{self, EncodeOptions, JweContentEncryption, JweKeyManagement, KeyData};
+use serde_json::json;
+
+/// Minimal dictionary crack over the public verifier, standing in for the
+/// `crack` command's dictionary mode.
+fn dictionary_crack(token: &str, wordlist: &[&str]) -> Option<String> {
+    let verifier = jwt::prepare_hs256_verifier(token).ok()?;
+    wordlist
+        .iter()
+        .find(|w| verifier.verify(w.as_bytes()))
+        .map(|w| w.to_string())
+}
+
+/// Minimal brute-force crack using the same primitives as the crack hot path.
+fn brute_crack(token: &str, chars: &str, max_len: usize) -> Option<String> {
+    let verifier = jwt::prepare_hs256_verifier(token).ok()?;
+    let char_bytes = brute::charset_bytes(chars);
+    let mut buf = Vec::new();
+    for length in 1..=max_len {
+        let total = (char_bytes.len() as u64).pow(length as u32);
+        for idx in 0..total {
+            brute::write_candidate_bytes(idx, &char_bytes, length, &mut buf);
+            if verifier.verify(&buf) {
+                return Some(String::from_utf8(buf).unwrap());
+            }
+        }
+    }
+    None
+}
+
+/// Scenario 1: HS256 encode -> dictionary crack -> verify.
+#[test]
+fn e2e_hs256_encode_dictionary_crack_verify() {
+    let secret = "letmein";
+    let claims = json!({"sub": "1234567890", "name": "Alice", "role": "admin"});
+
+    // Encode
+    let token = jwt::encode(&claims, secret, "HS256").expect("encode");
+    assert_eq!(jwt::detect_token_type(&token), jwt::TokenType::Jwt);
+
+    // Crack (dictionary)
+    let found = dictionary_crack(&token, &["nope", "wrong", secret, "other"]);
+    assert_eq!(found.as_deref(), Some(secret));
+
+    // Verify with the recovered secret succeeds, and a wrong one fails.
+    assert!(jwt::verify(&token, secret).expect("verify ok"));
+    assert!(!jwt::verify(&token, "not-the-secret").expect("verify wrong"));
+
+    // Decode round-trips the claims.
+    let decoded = jwt::decode(&token).expect("decode");
+    assert_eq!(decoded.claims["name"], "Alice");
+    assert_eq!(decoded.claims["role"], "admin");
+}
+
+/// Scenario 2: HS256 encode -> brute-force crack -> verify.
+#[test]
+fn e2e_hs256_encode_brute_crack_verify() {
+    let secret = "cab";
+    let token = jwt::encode(&json!({"sub": "x"}), secret, "HS256").expect("encode");
+
+    let found = brute_crack(&token, "abc", 3);
+    assert_eq!(found.as_deref(), Some(secret));
+
+    assert!(jwt::verify(&token, secret).expect("verify"));
+}
+
+/// Scenario 3: compressed payload round-trip -> decode -> verify.
+#[test]
+fn e2e_compressed_payload_roundtrip() {
+    let secret = "s3cr3t";
+    let claims = json!({"sub": "1234", "data": "a".repeat(200)});
+
+    let options = EncodeOptions {
+        algorithm: "HS256",
+        key_data: KeyData::Secret(secret),
+        header_params: None,
+        compress_payload: true,
+    };
+    let token = jwt::encode_with_options(&claims, &options).expect("encode compressed");
+
+    // Header advertises DEFLATE compression.
+    let decoded = jwt::decode(&token).expect("decode");
+    assert_eq!(
+        decoded.header.get("zip").and_then(|v| v.as_str()),
+        Some("DEF")
+    );
+
+    // Claims survive the compress -> decode round-trip.
+    assert_eq!(decoded.claims["sub"], "1234");
+    assert_eq!(decoded.claims["data"], "a".repeat(200));
+
+    // Signature still verifies against the original secret.
+    assert!(jwt::verify(&token, secret).expect("verify compressed"));
+}
+
+/// Scenario 4: `none` algorithm token encode -> decode.
+#[test]
+fn e2e_none_algorithm_token() {
+    let options = EncodeOptions {
+        algorithm: "none",
+        key_data: KeyData::None,
+        header_params: None,
+        compress_payload: false,
+    };
+    let token = jwt::encode_with_options(&json!({"sub": "admin"}), &options).expect("encode none");
+
+    let decoded = jwt::decode(&token).expect("decode none");
+    assert_eq!(
+        decoded.header.get("alg").and_then(|v| v.as_str()),
+        Some("none")
+    );
+    assert_eq!(decoded.claims["sub"], "admin");
+    // The library `verify` accepts `alg:none` tokens regardless of the secret —
+    // this is exactly the alg:none acceptance pitfall jwt-hack helps surface, so
+    // we pin the behavior here rather than assume signature enforcement.
+    assert!(jwt::verify(&token, "anything").expect("verify none"));
+}
+
+/// Scenario 5: JWE (direct symmetric key) encrypt -> detect -> decrypt.
+#[test]
+fn e2e_jwe_direct_roundtrip() {
+    // A256GCM direct encryption needs a 32-byte key.
+    let key = "0123456789abcdef0123456789abcdef";
+    let payload = r#"{"sub":"1234","secret_data":"top secret"}"#;
+
+    let token = jwt::encode_jwe(
+        payload,
+        JweKeyManagement::Direct(key),
+        JweContentEncryption::A256GCM,
+    )
+    .expect("encode jwe");
+
+    assert_eq!(jwt::detect_token_type(&token), jwt::TokenType::Jwe);
+
+    let decrypted = jwt::decrypt_jwe(&token, key).expect("decrypt jwe");
+    assert_eq!(decrypted, payload);
+
+    // The wrong key must not decrypt.
+    let wrong = "ffffffffffffffffffffffffffffffff";
+    assert!(jwt::decrypt_jwe(&token, wrong).is_err());
+}

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1,0 +1,115 @@
+//! Cross-library interoperability tests.
+//!
+//! jwt-hack signs/verifies JWTs through `jsonwebtoken` internally. These tests
+//! validate that tokens are interoperable with a *different* JWT/JWS
+//! implementation — `josekit` — in both directions and across symmetric (HS256)
+//! and asymmetric (RS256) algorithms.
+
+use josekit::jws::{JwsHeader, HS256, RS256};
+use jwt_hack::jwt::{self, EncodeOptions, KeyData};
+use serde_json::{json, Value};
+
+const RSA_PRIVATE_PEM: &str = include_str!("../src/jwt/test_rsa_2048_private.pem");
+const RSA_PUBLIC_PEM: &str = include_str!("../src/jwt/test_rsa_2048_public.pem");
+
+/// jwt-hack signs an HS256 token; josekit (a different library) must verify it
+/// and read back the exact claims.
+#[test]
+fn interop_hs256_jwthack_encode_josekit_verify() {
+    // josekit enforces the RFC 7518 minimum HMAC key size (>= 32 bytes for HS256).
+    let secret = "0123456789abcdef0123456789abcdef";
+    let claims = json!({"sub": "1234567890", "name": "Alice", "admin": true});
+
+    let token = jwt::encode(&claims, secret, "HS256").expect("jwt-hack encode");
+
+    let verifier = HS256
+        .verifier_from_bytes(secret.as_bytes())
+        .expect("josekit verifier");
+    let (payload_bytes, header) =
+        josekit::jws::deserialize_compact(&token, &verifier).expect("josekit verify");
+
+    assert_eq!(header.algorithm(), Some("HS256"));
+    let payload: Value = serde_json::from_slice(&payload_bytes).expect("payload json");
+    assert_eq!(payload["name"], "Alice");
+    assert_eq!(payload["admin"], true);
+
+    // A wrong secret must be rejected by the other library too.
+    let bad = HS256
+        .verifier_from_bytes(b"ffffffffffffffffffffffffffffffff")
+        .expect("verifier");
+    assert!(josekit::jws::deserialize_compact(&token, &bad).is_err());
+}
+
+/// josekit signs an HS256 token; jwt-hack must verify and decode it.
+#[test]
+fn interop_hs256_josekit_encode_jwthack_verify() {
+    // josekit enforces the RFC 7518 minimum HMAC key size (>= 32 bytes for HS256).
+    let secret = "0123456789abcdef0123456789abcdef";
+
+    let mut header = JwsHeader::new();
+    header.set_algorithm("HS256");
+    header.set_token_type("JWT");
+    let payload = serde_json::to_vec(&json!({"sub": "42", "name": "Bob"})).unwrap();
+    let signer = HS256
+        .signer_from_bytes(secret.as_bytes())
+        .expect("josekit signer");
+    let token = josekit::jws::serialize_compact(&payload, &header, &signer).expect("josekit sign");
+
+    // jwt-hack verifies the josekit-produced token.
+    assert!(jwt::verify(&token, secret).expect("jwt-hack verify"));
+    assert!(!jwt::verify(&token, "wrong").expect("jwt-hack verify wrong"));
+
+    // jwt-hack decodes the josekit-produced claims.
+    let decoded = jwt::decode(&token).expect("jwt-hack decode");
+    assert_eq!(decoded.claims["name"], "Bob");
+    assert_eq!(decoded.claims["sub"], "42");
+}
+
+/// jwt-hack signs an RS256 token with a private key; josekit must verify it with
+/// the matching public key (asymmetric cross-library interop).
+#[test]
+fn interop_rs256_jwthack_encode_josekit_verify() {
+    let claims = json!({"sub": "rsa-user", "scope": "read"});
+    let options = EncodeOptions {
+        algorithm: "RS256",
+        key_data: KeyData::PrivateKeyPem(RSA_PRIVATE_PEM),
+        header_params: None,
+        compress_payload: false,
+    };
+    let token = jwt::encode_with_options(&claims, &options).expect("jwt-hack RS256 encode");
+
+    let verifier = RS256
+        .verifier_from_pem(RSA_PUBLIC_PEM.as_bytes())
+        .expect("josekit RS256 verifier");
+    let (payload_bytes, header) =
+        josekit::jws::deserialize_compact(&token, &verifier).expect("josekit RS256 verify");
+
+    assert_eq!(header.algorithm(), Some("RS256"));
+    let payload: Value = serde_json::from_slice(&payload_bytes).expect("payload json");
+    assert_eq!(payload["sub"], "rsa-user");
+    assert_eq!(payload["scope"], "read");
+}
+
+/// josekit signs an RS256 token; jwt-hack must verify it with the public key.
+#[test]
+fn interop_rs256_josekit_encode_jwthack_verify() {
+    let mut header = JwsHeader::new();
+    header.set_algorithm("RS256");
+    header.set_token_type("JWT");
+    let payload = serde_json::to_vec(&json!({"sub": "rsa-user-2"})).unwrap();
+    let signer = RS256
+        .signer_from_pem(RSA_PRIVATE_PEM.as_bytes())
+        .expect("josekit RS256 signer");
+    let token = josekit::jws::serialize_compact(&payload, &header, &signer).expect("josekit sign");
+
+    let options = jwt::VerifyOptions {
+        key_data: jwt::VerifyKeyData::PublicKeyPem(RSA_PUBLIC_PEM),
+        validate_exp: false,
+        validate_nbf: false,
+        leeway: 0,
+    };
+    assert!(jwt::verify_with_options(&token, &options).expect("jwt-hack RS256 verify"));
+
+    let decoded = jwt::decode(&token).expect("jwt-hack decode");
+    assert_eq!(decoded.claims["sub"], "rsa-user-2");
+}


### PR DESCRIPTION
## Summary

Implements and resolves three issues in one changeset.

### #80 — `crack`: add `-p` / `--wordlist-preset`
- New `crack::wordlist_preset` module resolves a numbered preset to a well-known wordlist, downloads it into the config dir (`<config>/jwt-hack/wordlists/`) on first use, and caches it.
- A SHA-256 sidecar is written next to each download; a cached copy whose hash still matches is served from disk, **skipping re-download** (as the issue asked). A hash mismatch forces a fresh download.
- Presets: `1=raft-medium-words`, `2=raft-large-words`, `3=jwt-secrets`.
- Wired `-p/--wordlist-preset` into the crack command (precedence: preset → `--wordlist` → config default). The download logic is factored so the caching/integrity core is unit-tested offline with an injected downloader.

### #180 — Tests: server, shell, E2E, interop
- **Server** (`cmd/server.rs`): router-level tests driving *mock HTTP requests* through `build_router` for every endpoint — health, decode, encode, verify, crack (brute + inline dict), payload, scan, plus 404, malformed-JSON, and API-key gating.
- **Shell** (`cmd/shell/mod.rs`): command parsing/execution tests for encode/verify/payload/crack/scan dispatch, error paths, and a full `set … / show` workflow.
- **E2E** (`tests/e2e.rs`): 5 full workflows — encode→dictionary-crack→verify, encode→brute-crack→verify, compressed-payload round-trip, `alg:none`, and JWE direct round-trip.
- **Interop** (`tests/interop.rs`): cross-library validation against **josekit** for HS256 and RS256 in both directions (jwt-hack↔josekit).

### #184 — Infra: criterion benchmarks + cargo-fuzz
- **Benchmarks** (`benches/jwt_benchmarks.rs`): Criterion suite covering encode, decode, verify, and cracking (dict + brute). Added `criterion` dev-dependency and a `[[bench]]` target.
- **Fuzzing** (`fuzz/`): libfuzzer targets for JWT decode, JWE decode, and header parsing.
- Exposed `crack` in the library crate so benches/tests can reach the brute-force primitives.
- **CI**: `benchmarks.yml` compares against a baseline via `github-action-benchmark` (publishes baseline from `main`, non-blocking PR alerts); `fuzz.yml` runs time-boxed nightly `cargo-fuzz` on a weekly schedule / manual dispatch.
- Added `just bench` / `just fuzz` recipes and documented both in `AGENTS.md`.

## Testing
- `cargo test` — 353 unit + 5 E2E + 4 interop tests pass; benchmarks are **not** run under `cargo test`.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo doc --workspace --all-features --no-deps --document-private-items` — clean.
- Manually verified `crack -p 3` downloads → caches (with `.sha256` sidecar) → cracks, and a second run reuses the cache without re-downloading.

Closes #80
Closes #180
Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5egmoKZqnpgvEB22u5avz)_