### PR TITLE
docs: fix unclosed code fence in README encode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can use the `--compress` option to apply DEFLATE compression to the JWT payl
 jwt-hack encode '{"sub":"1234"}' --secret=your-secret --compress
 ```
 
+```bash
 # With Private Key
 ssh-keygen -t rsa -b 4096 -E SHA256 -m PEM -P "" -f RS256.key
 jwt-hack encode '{"a":"z"}' --private-key RS256.key --algorithm=RS256


### PR DESCRIPTION
## What

The "With Private Key" example in the *Encode a JWT* section is missing its
opening code fence, so the fence count in README.md is odd (43).

## Why it matters

Because the fence at line 109 opens a block instead of closing one, GitHub
currently renders the section like this:

| | Before | After |
|---|---|---|
| `# With Private Key` | `<h1>` — larger than every other heading on the page | inside a `bash` block, as intended |
| `ssh-keygen` / `jwt-hack encode` | bare paragraph text | inside the same block |
| `### Encode a JWE` | **swallowed into a `<pre>` — the heading disappears** | `<h3>`, as intended |

Reproduced with GitHub's own renderer:

```bash
gh api --method POST /markdown -f text="$(sed -n '92,119p' README.md)" -f mode=markdown
```

Before → `<h3>Encode a JWT`, `<pre>`, `<h4>…DEFLATE Compression`, `<pre>`, `<h1>With Private Key`, `<pre>`
After  → `<h3>Encode a JWT`, `<pre>`, `<h4>…DEFLATE Compression`, `<pre>`, `<pre>`, `<h3>Encode a JWE`, `<pre>`

## How it happened

Before cfeb755b the section was a single `bash` block holding both
`# With Secret` and `# With Private Key` as shell comments. cfeb755b
("Add DEFLATE compression support details to README", 2025-08-10) inserted the
compression example into the middle of it, closing the first half and leaving
the private-key half without an opening fence.

## The fix

One added line. `grep -c '^```' README.md` goes 43 → 44.

## Note for the reviewer

This is the minimal fix and it leaves the private-key example rendered *under*
the `#### Encode a JWT with DEFLATE Compression` heading, which reads a little
oddly since it has nothing to do with compression. If you'd prefer, I'm happy to
follow up by moving that block back up under `### Encode a JWT` to restore the
pre-cfeb755b structure — I kept this PR to the rendering bug alone.