### PR TITLE
docs: fix broken Next Steps links in quickstart

### DIFF
--- a/docs/content/get_started/quickstart.md
+++ b/docs/content/get_started/quickstart.md
@@ -50,6 +50,6 @@ jwt-hack payload eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.INVALI
 
 ## Next Steps
 
-- Explore the [Usage Guide](/usage/decode) for detailed command explanations
-- Learn about [Advanced Features](/advanced/configuration) and configuration options
-- Check out the [Contributing Guide](/contributing) if you want to help improve JWT-HACK
+- Explore the [Usage Guide](/usage/commands/decode) for detailed command explanations
+- Learn about [Advanced Features](/usage/configuration) and configuration options
+- Check out the [Contributing Guide](/support/contributing) if you want to help improve JWT-HACK


### PR DESCRIPTION
## What

The three links in *Next Steps* on the Quickstart page all 404 on the live docs
site.

| Link text | Current target | Status | Should be | Status |
|---|---|---|---|---|
| Usage Guide | `/usage/decode` | **404** | `/usage/commands/decode` | 200 |
| Advanced Features | `/advanced/configuration` | **404** | `/usage/configuration` | 200 |
| Contributing Guide | `/contributing` | **404** | `/support/contributing` | 200 |

Verified against `base_url = "https://jwt-hack.hahwul.com"` from `docs/config.toml`:

```bash
for u in usage/decode advanced/configuration contributing \
         usage/commands/decode usage/configuration support/contributing; do
  printf "%s  %s\n" "$(curl -o /dev/null -s -w '%{http_code}' "https://jwt-hack.hahwul.com/$u/")" "$u"
done
```

None of the three broken paths appear in `sitemap.xml`. The rendered Quickstart
page also contradicts itself: the body links to `/usage/decode` while the
auto-generated sidebar on the same page links to `/usage/commands/decode/`.

## How it happened

74b83c3 ("Restructure documentation according to new organization", 2025-12-25)
moved these pages. The *Next Steps* section was added later, in d7a2ce0
("Docs update", 2026-03-02), pointing at the pre-restructure paths — the correct
targets (`usage/commands/decode.md`, `usage/configuration.md`,
`support/contributing.md`) already existed at that commit. So these links have
never resolved.

## Scope

A crawl of every internal link under `docs/content/` finds exactly these three
broken targets repo-wide, and zero after this change. The replacements are the
paths the rest of the docs already use (`usage/commands/_index.md`,
`reference/environment-variables.md`, `support/_index.md`, `support/community.md`).

## One judgement call

The second link's text says "Advanced Features" but its target is a
configuration page. I pointed it at `/usage/configuration` to match both the
link text ("...and configuration options") and the sidebar the site generates.
If you'd rather it go to `/advanced/` (which holds performance-optimization and
scripting-automation), say the word and I'll change it.