### PR TITLE
fix(scan): report expired tokens with missing claims or float exp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixed
 - `decode` no longer rejects tokens whose `alg` is absent from jsonwebtoken's enum: ES512 tokens (which `encode` itself produces via josekit) and tokens with exotic/attacker-chosen `alg` values now decode for inspection instead of erroring with "Unsupported algorithm"
 - `decode` (CLI, `--json`, MCP, and REST server) now reports the token's real `alg` from the header — an `alg:none` token is shown as `none` rather than being mislabelled `HS256` (an artifact of the internal HS256 sentinel). Verification and the fast HS256 crack path still key off the real header `alg`, so an unrepresentable alg returns a clear "unsupported" error instead of a silent HMAC comparison
+- `scan` expiration check now reports an expired token even when `iat`/`nbf` are also missing (the "Token is expired" message was previously dropped in favour of the missing-claims list), and evaluates float `exp` values (RFC 7519 §2 allows non-integer NumericDate) that a bare `as_i64()` silently skipped — same float-aware reading now applies to the REST `/scan` endpoint
 
 ### Performance
 - Reduced peak memory ~99% (15.9 GB → ~10 MB) via mimalloc and 100K-entry streaming wordlist batches, while throughput rose ~53% (939K → 1.44M keys/sec); `--power` pool capped at 32 (#208)

--- a/src/cmd/decode.rs
+++ b/src/cmd/decode.rs
@@ -16,13 +16,10 @@ fn format_unix_timestamp(seconds: i64) -> Option<String> {
 }
 
 /// Reads a NumericDate claim (`exp`/`iat`) as seconds. Accepts both integer and
-/// float JSON numbers (RFC 7519 allows non-integer NumericDate). Float→int uses
-/// Rust's saturating cast and non-finite values are rejected; out-of-range values
-/// are later dropped by `format_unix_timestamp` rather than panicking.
+/// float JSON numbers (RFC 7519 allows non-integer NumericDate). Out-of-range
+/// values are later dropped by `format_unix_timestamp` rather than panicking.
 fn claim_seconds(value: &Value) -> Option<i64> {
-    value
-        .as_i64()
-        .or_else(|| value.as_f64().filter(|f| f.is_finite()).map(|f| f as i64))
+    utils::numeric_date_seconds(value)
 }
 
 /// Annotate issued-at claim with human-readable timestamp in the JSON output

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -628,9 +628,28 @@ fn check_token_expiration(decoded: &jwt::DecodedToken) -> Result<VulnerabilityRe
 
     let mut issues = Vec::new();
 
-    if !has_exp {
-        issues.push("Missing 'exp' (expiration) claim".to_string());
-    } else if let Some(exp) = decoded.claims.get("exp").and_then(|v| v.as_i64()) {
+    // Report missing lifetime claims first, then the expiry status. Both must be
+    // able to appear together: previously, when any claim was missing the details
+    // dropped the "Token is expired" message entirely (it showed only the missing
+    // claims), so an expired token that also lacked `iat`/`nbf` was never reported
+    // as expired.
+    let missing_claims: Vec<&str> = [(!has_exp, "exp"), (!has_nbf, "nbf"), (!has_iat, "iat")]
+        .iter()
+        .filter(|(missing, _)| *missing)
+        .map(|(_, name)| *name)
+        .collect();
+    if !missing_claims.is_empty() {
+        issues.push(format!("Missing '{}'", missing_claims.join("', '")));
+    }
+
+    // Evaluate expiry with a NumericDate reader that accepts float values too
+    // (RFC 7519 §2). A bare `as_i64()` returned `None` for a valid float `exp`,
+    // silently letting an expired float-dated token pass the expiration check.
+    if let Some(exp) = decoded
+        .claims
+        .get("exp")
+        .and_then(utils::numeric_date_seconds)
+    {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before UNIX epoch")
@@ -641,29 +660,12 @@ fn check_token_expiration(decoded: &jwt::DecodedToken) -> Result<VulnerabilityRe
         }
     }
 
-    if !has_nbf {
-        issues.push("Missing 'nbf' (not before) claim".to_string());
-    }
-
-    if !has_iat {
-        issues.push("Missing 'iat' (issued at) claim".to_string());
-    }
-
     let vulnerable = !issues.is_empty();
-    let missing_claims: Vec<&str> = [(!has_exp, "exp"), (!has_nbf, "nbf"), (!has_iat, "iat")]
-        .iter()
-        .filter(|(missing, _)| *missing)
-        .map(|(_, name)| *name)
-        .collect();
     let result = VulnerabilityResult {
         name: "Token Expiration".to_string(),
         vulnerable,
         details: if vulnerable {
-            if missing_claims.is_empty() {
-                issues.join("; ")
-            } else {
-                format!("Missing '{}'", missing_claims.join("', '"))
-            }
+            issues.join("; ")
         } else {
             "Proper expiration claims".to_string()
         },
@@ -1612,6 +1614,54 @@ mod tests {
         // Token has exp claim, so might report missing nbf/iat but not critically vulnerable
         // The exact result depends on the token structure
         assert!(result.name == "Token Expiration");
+    }
+
+    #[test]
+    fn test_check_token_expiration_float_exp_is_detected() {
+        // RFC 7519 §2 allows a non-integer NumericDate. A float `exp` in the past
+        // must still be reported as expired (regression: `as_i64()` returned None
+        // for floats, silently skipping the check).
+        let token = synthetic_token(json!({}), json!({ "sub": "x", "exp": 1_000_000_000.5 }));
+        let decoded = jwt::decode(&token).unwrap();
+        let result = check_token_expiration(&decoded).unwrap();
+        assert!(result.vulnerable);
+        assert!(
+            result.details.contains("expired"),
+            "float exp should be reported as expired, got: {}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn test_check_token_expiration_reports_expiry_even_when_claims_missing() {
+        // Regression: when `iat`/`nbf` were also missing, the details dropped the
+        // "Token is expired" message and showed only the missing claims.
+        let token = synthetic_token(json!({}), json!({ "sub": "x", "exp": 1_000_000_000 }));
+        let decoded = jwt::decode(&token).unwrap();
+        let result = check_token_expiration(&decoded).unwrap();
+        assert!(result.vulnerable);
+        assert!(
+            result.details.contains("expired"),
+            "expiry must be reported alongside missing claims, got: {}",
+            result.details
+        );
+        assert!(
+            result.details.contains("Missing"),
+            "missing claims should still be reported, got: {}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn test_check_token_expiration_valid_when_all_present_and_fresh() {
+        let token = synthetic_token(
+            json!({}),
+            json!({ "sub": "x", "exp": 9_999_999_999i64, "nbf": 1, "iat": 1 }),
+        );
+        let decoded = jwt::decode(&token).unwrap();
+        let result = check_token_expiration(&decoded).unwrap();
+        assert!(!result.vulnerable);
+        assert_eq!(result.details, "Proper expiration claims");
     }
 
     #[test]

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -602,13 +602,16 @@ async fn handle_scan(Json(req): Json<ScanRequest>) -> Result<Json<ScanResponse>,
                 }
             }
 
-            // Check for expired tokens
-            if let Some(exp) = decoded.claims.get("exp") {
-                if let Some(exp_val) = exp.as_i64() {
-                    let now = chrono::Utc::now().timestamp();
-                    if exp_val < now {
-                        vulnerabilities.push("Token is expired".to_string());
-                    }
+            // Check for expired tokens. Read the NumericDate with a float-aware
+            // helper (RFC 7519 §2) so a valid float `exp` isn't silently skipped.
+            if let Some(exp_val) = decoded
+                .claims
+                .get("exp")
+                .and_then(utils::numeric_date_seconds)
+            {
+                let now = chrono::Utc::now().timestamp();
+                if exp_val < now {
+                    vulnerabilities.push("Token is expired".to_string());
                 }
             }
         }

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -695,7 +695,11 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
     if algorithm_from_str(raw_alg).is_none() {
         return Err(anyhow!(
             "Unsupported algorithm for verification: {}",
-            if raw_alg.is_empty() { "<missing>" } else { raw_alg }
+            if raw_alg.is_empty() {
+                "<missing>"
+            } else {
+                raw_alg
+            }
         ));
     }
 
@@ -2448,8 +2452,7 @@ mod tests {
         // alg (via `alg_str`) must be the real `none`, not the misleading HS256.
         let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(br#"{"alg":"none","typ":"JWT"}"#);
-        let claims_b64 =
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
         let token = format!("{header_b64}.{claims_b64}.");
         let decoded = decode(&token).expect("decode of none token should succeed");
         assert_eq!(decoded.alg_str(), "none");
@@ -2462,8 +2465,7 @@ mod tests {
         // `alg`; `decode` should surface the raw value rather than erroring.
         let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(br#"{"alg":"FOO123","typ":"JWT"}"#);
-        let claims_b64 =
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
         let token = format!("{header_b64}.{claims_b64}.AAAA");
         let decoded = decode(&token).expect("decode of unknown-alg token should succeed");
         assert_eq!(decoded.alg_str(), "FOO123");
@@ -2476,8 +2478,7 @@ mod tests {
         // Ok(false) (which would imply a valid HMAC comparison was performed).
         let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(br#"{"alg":"ES512","typ":"JWT"}"#);
-        let claims_b64 =
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
         let token = format!("{header_b64}.{claims_b64}.AAAA");
         let err = verify(&token, "secret").unwrap_err().to_string();
         assert!(
@@ -2492,8 +2493,7 @@ mod tests {
         // cracking path must key off the real header alg and refuse it.
         let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(br#"{"alg":"FOO123","typ":"JWT"}"#);
-        let claims_b64 =
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
         let token = format!("{header_b64}.{claims_b64}.AAAA");
         assert!(prepare_hs256_verifier(&token).is_err());
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -100,6 +100,20 @@ pub fn format_duration(duration: std::time::Duration) -> String {
     format!("{hours}h {remain_minutes}m {remain_seconds}s")
 }
 
+/// Read a JWT NumericDate claim (`exp`/`nbf`/`iat`) as whole seconds.
+///
+/// RFC 7519 §2 defines NumericDate as a JSON number that MAY be non-integer, so
+/// this accepts both integer and float JSON values (a float is truncated toward
+/// zero via a saturating cast; non-finite floats are rejected). Returns `None`
+/// for any non-numeric value. Centralizing this avoids the trap of reading a
+/// claim with a bare `as_i64()`, which silently returns `None` for a perfectly
+/// valid float date — causing e.g. an expired token to escape detection.
+pub fn numeric_date_seconds(value: &serde_json::Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().filter(|f| f.is_finite()).map(|f| f as i64))
+}
+
 /// Compares two byte slices in constant time relative to their content.
 ///
 /// Returns `false` immediately on a length mismatch (lengths are not secret), but
@@ -270,6 +284,25 @@ mod tests {
         let input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
         let expected = "ABCDEFGH...456789+/ (64 chars)";
         assert_eq!(format_base64_preview(input), expected);
+    }
+
+    #[test]
+    fn test_numeric_date_seconds() {
+        use serde_json::json;
+        assert_eq!(
+            numeric_date_seconds(&json!(1_700_000_000i64)),
+            Some(1_700_000_000)
+        );
+        // Float NumericDate (RFC 7519 §2) is truncated toward zero.
+        assert_eq!(
+            numeric_date_seconds(&json!(1_700_000_000.9_f64)),
+            Some(1_700_000_000)
+        );
+        assert_eq!(numeric_date_seconds(&json!(-1.0_f64)), Some(-1));
+        // Non-finite and non-numeric values are rejected.
+        assert_eq!(numeric_date_seconds(&json!("1700000000")), None);
+        assert_eq!(numeric_date_seconds(&json!(f64::INFINITY)), None);
+        assert_eq!(numeric_date_seconds(&serde_json::Value::Null), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`scan`'s `check_token_expiration` silently under-reported expired tokens in **two** ways (both confirmed via the CLI):

1. **Expiry message suppressed when other claims are missing.** When `iat`/`nbf` were also absent, the details string dropped the "Token is expired" message and showed *only* the missing-claims list — so an expired token that lacked `iat`/`nbf` was never reported as expired.
2. **Float `exp` skipped.** `exp` was read with a bare `as_i64()`, which returns `None` for a JSON float. RFC 7519 §2 permits a non-integer NumericDate, so a float `exp` in the past passed the expiration check. The REST `/scan` endpoint had the same `as_i64()`-only bug.

`decode` already handled float NumericDate (it has `claim_seconds` + tests), so this was an inconsistency between commands.

## Fix

- Merge missing-claims and expiry status into the details so both appear together.
- Add `utils::numeric_date_seconds` (integer + finite-float aware) and use it in `scan` and the REST `/scan` handler; `decode::claim_seconds` now delegates to it (removing the duplicate).
- Ran `cargo fmt`, which also repairs formatting drift that merged in #260 (its `lint` job was red).

## Testing

- New regression tests: float `exp` detected, expiry reported alongside missing claims, all-present-and-fresh stays non-vulnerable, and the `numeric_date_seconds` helper.
- Full suite: **531 tests pass**, clippy clean, `cargo fmt --check` clean.

### Before / after (CLI)
Expired token with a float `exp` (`1000000000.5`, year 2001):
- before: `Token Expiration → Missing 'nbf', 'iat'` (not flagged expired)
- after: `Token Expiration → Missing 'nbf', 'iat'; Token is expired (exp: 1000000000)`