### PR TITLE
fix(scan): report both jku and x5u when both headers present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `decode` (CLI, `--json`, MCP, and REST server) now reports the token's real `alg` from the header — an `alg:none` token is shown as `none` rather than being mislabelled `HS256` (an artifact of the internal HS256 sentinel). Verification and the fast HS256 crack path still key off the real header `alg`, so an unrepresentable alg returns a clear "unsupported" error instead of a silent HMAC comparison
 - `scan` expiration check now reports an expired token even when `iat`/`nbf` are also missing (the "Token is expired" message was previously dropped in favour of the missing-claims list), and evaluates float `exp` values (RFC 7519 §2 allows non-integer NumericDate) that a bare `as_i64()` silently skipped — same float-aware reading now applies to the REST `/scan` endpoint
 - `encode --jwe` now performs real AES-GCM encryption via josekit (A128GCM for a 16-byte `--secret`, A256GCM for 32 bytes) instead of emitting a deprecated demo token whose "ciphertext" was the plaintext base64url-encoded with a dummy IV/tag and the key ignored; an unusable key length is now a clear error. Applies to both the CLI and `--json` output
+- `scan` now reports both `jku` and `x5u` when a token carries both headers; previously only the first was surfaced, silently hiding the `x5u` URL-spoofing / SSRF risk
 
 ### Performance
 - Reduced peak memory ~99% (15.9 GB → ~10 MB) via mimalloc and 100K-entry streaming wordlist batches, while throughput rose ~53% (939K → 1.44M keys/sec); `--power` pool capped at 32 (#208)

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1034,29 +1034,35 @@ fn check_sensitive_claims(decoded: &jwt::DecodedToken) -> Result<VulnerabilityRe
 
 /// Check for JKU/X5U header vulnerabilities
 fn check_jku_x5u_vulnerabilities(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
-    let has_jku = decoded.header.contains_key("jku");
-    let has_x5u = decoded.header.contains_key("x5u");
+    // Report every URL-bearing header that is present. Previously only the first
+    // of `jku`/`x5u` was surfaced (`if has_jku { "jku" } else { "x5u" }`), so a
+    // token carrying both silently hid the `x5u` spoofing/SSRF risk.
+    let present: Vec<String> = ["jku", "x5u"]
+        .iter()
+        .filter_map(|h| {
+            decoded.header.get(*h).map(|v| {
+                let value = v
+                    .as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| v.to_string());
+                format!("'{}' ({})", h, value)
+            })
+        })
+        .collect();
 
-    let result = if has_jku || has_x5u {
-        let header_type = if has_jku { "jku" } else { "x5u" };
-        let header_value = decoded.header.get(header_type);
-
-        VulnerabilityResult {
-            name: "JKU/X5U Header".to_string(),
-            vulnerable: true,
-            details: format!(
-                "Has '{}' header ({}), URL spoofing risk",
-                header_type,
-                header_value.map(|v| v.to_string()).unwrap_or_default()
-            ),
-            severity: Severity::High,
-        }
-    } else {
+    let result = if present.is_empty() {
         VulnerabilityResult {
             name: "JKU/X5U Header".to_string(),
             vulnerable: false,
             details: "No JKU/X5U headers".to_string(),
             severity: Severity::Info,
+        }
+    } else {
+        VulnerabilityResult {
+            name: "JKU/X5U Header".to_string(),
+            vulnerable: true,
+            details: format!("Has {} — URL spoofing / SSRF risk", present.join(" and ")),
+            severity: Severity::High,
         }
     };
 
@@ -1662,6 +1668,44 @@ mod tests {
         let result = check_token_expiration(&decoded).unwrap();
         assert!(!result.vulnerable);
         assert_eq!(result.details, "Proper expiration claims");
+    }
+
+    #[test]
+    fn test_check_jku_x5u_reports_both_when_present() {
+        // Regression: a token carrying both jku and x5u must surface both; the old
+        // code reported only jku and hid the x5u spoofing/SSRF risk.
+        let token = synthetic_token(
+            json!({ "jku": "https://evil.example/jwks", "x5u": "https://evil.example/cert" }),
+            json!({ "sub": "x" }),
+        );
+        let decoded = jwt::decode(&token).unwrap();
+        let result = check_jku_x5u_vulnerabilities(&decoded).unwrap();
+        assert!(result.vulnerable);
+        assert!(
+            result.details.contains("jku"),
+            "details: {}",
+            result.details
+        );
+        assert!(
+            result.details.contains("x5u"),
+            "details: {}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn test_check_jku_x5u_single_and_none() {
+        // Only x5u present -> reported.
+        let x5u_only = synthetic_token(json!({ "x5u": "https://e/cert" }), json!({ "sub": "x" }));
+        let d = jwt::decode(&x5u_only).unwrap();
+        let r = check_jku_x5u_vulnerabilities(&d).unwrap();
+        assert!(r.vulnerable && r.details.contains("x5u") && !r.details.contains("jku"));
+
+        // Neither present -> not vulnerable.
+        let none = synthetic_token(json!({}), json!({ "sub": "x" }));
+        let d = jwt::decode(&none).unwrap();
+        let r = check_jku_x5u_vulnerabilities(&d).unwrap();
+        assert!(!r.vulnerable);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`scan`'s `check_jku_x5u_vulnerabilities` reported only **one** of the two URL-bearing headers:

```rust
let header_type = if has_jku { "jku" } else { "x5u" };
```

So a token carrying **both** `jku` and `x5u` surfaced only the `jku` finding and silently hid the `x5u` URL-spoofing / SSRF risk.

### Before
```
$ jwt-hack scan <token with both jku and x5u>
JKU/X5U Header → Has 'jku' ("https://evil/jwks"), URL spoofing risk
# x5u not mentioned
```

## Fix

Collect every URL-bearing header that is present and list them all:

```
JKU/X5U Header → Has 'jku' (https://evil/jwks) and 'x5u' (https://evil/cert) — URL spoofing / SSRF risk
```

The result `name` and `vulnerable` semantics are unchanged, so payload collection (which keys off the name to enable the `jku`/`x5u` attack targets) is unaffected.

## Testing

- New regression tests: both-present (both surfaced), x5u-only, and neither.
- Full suite: **536 tests pass**, clippy clean, `cargo fmt --check` clean.