### PR TITLE
fix(jwks): verify against oct keys with raw bytes, not lossy UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `scan` expiration check now reports an expired token even when `iat`/`nbf` are also missing (the "Token is expired" message was previously dropped in favour of the missing-claims list), and evaluates float `exp` values (RFC 7519 §2 allows non-integer NumericDate) that a bare `as_i64()` silently skipped — same float-aware reading now applies to the REST `/scan` endpoint
 - `encode --jwe` now performs real AES-GCM encryption via josekit (A128GCM for a 16-byte `--secret`, A256GCM for 32 bytes) instead of emitting a deprecated demo token whose "ciphertext" was the plaintext base64url-encoded with a dummy IV/tag and the key ignored; an unusable key length is now a clear error. Applies to both the CLI and `--json` output
 - `scan` now reports both `jku` and `x5u` when a token carries both headers; previously only the first was surfaced, silently hiding the `x5u` URL-spoofing / SSRF risk
+- `jwks --verify` now verifies tokens against symmetric (`oct`) JWKS keys using the raw key bytes; the key was previously routed through `String::from_utf8_lossy`, which replaced any non-UTF-8 byte with U+FFFD and made a correctly-signed token fail verification against its own binary key. Added `VerifyKeyData::SecretBytes` for byte-exact HMAC verification
 
 ### Performance
 - Reduced peak memory ~99% (15.9 GB → ~10 MB) via mimalloc and 100K-entry streaming wordlist batches, while throughput rose ~53% (939K → 1.44M keys/sec); `--power` pool capped at 32 (#208)

--- a/src/jwks/mod.rs
+++ b/src/jwks/mod.rs
@@ -371,9 +371,12 @@ pub fn verify_with_jwks(token: &str, jwks: &JwkSet) -> Result<Vec<KeyVerifyResul
                 if let Some(k) = &jwk.k {
                     match URL_SAFE_NO_PAD.decode(k) {
                         Ok(secret_bytes) => {
-                            let secret = String::from_utf8_lossy(&secret_bytes);
+                            // Use the raw key bytes verbatim. A JWKS `oct` key is
+                            // arbitrary binary; `from_utf8_lossy` would replace any
+                            // non-UTF-8 byte with U+FFFD and make verification of a
+                            // correctly-signed token fail.
                             let options = crate::jwt::VerifyOptions {
-                                key_data: crate::jwt::VerifyKeyData::Secret(&secret),
+                                key_data: crate::jwt::VerifyKeyData::SecretBytes(&secret_bytes),
                                 validate_exp: false,
                                 validate_nbf: false,
                                 leeway: 0,
@@ -753,6 +756,63 @@ mod tests {
         let jwks = JwkSet { keys: vec![] };
         let results = verify_with_jwks(&token, &jwks).unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_verify_with_jwks_oct_binary_key() {
+        // Regression: an `oct` JWK key is arbitrary bytes. Verifying a token
+        // signed with a non-UTF-8 key used to fail because the key was routed
+        // through `String::from_utf8_lossy`, replacing invalid bytes with U+FFFD.
+        // A key with an 0xFF byte is not valid UTF-8.
+        let key: [u8; 32] = [
+            0xff, 0xfe, 0x00, 0x80, 0x01, 0x02, 0x03, 0x90, 0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6,
+            0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x9f, 0xaf, 0xbf, 0xcf, 0xdf, 0xef,
+            0xff, 0x00, 0x11, 0x22,
+        ];
+        // The 0xFF bytes make this key invalid UTF-8, which is exactly the case
+        // `from_utf8_lossy` used to corrupt.
+
+        // Sign an HS256 token with the raw key bytes.
+        let h_b64 = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let c_b64 = URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let signing_input = format!("{h_b64}.{c_b64}");
+        let mac = hmac_sha256::HMAC::mac(signing_input.as_bytes(), key);
+        let sig_b64 = URL_SAFE_NO_PAD.encode(mac.as_slice());
+        let token = format!("{signing_input}.{sig_b64}");
+
+        let k_b64 = URL_SAFE_NO_PAD.encode(key);
+        let jwks_json =
+            format!(r#"{{"keys":[{{"kty":"oct","kid":"k1","alg":"HS256","k":"{k_b64}"}}]}}"#);
+        let jwks = parse_jwks(&jwks_json).unwrap();
+
+        let results = verify_with_jwks(&token, &jwks).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].valid,
+            "binary oct key must verify its correctly-signed token; error={:?}",
+            results[0].error
+        );
+    }
+
+    #[test]
+    fn test_verify_with_jwks_oct_wrong_key_is_invalid() {
+        // A different oct key must NOT verify (guards against the fix accepting
+        // everything).
+        let h_b64 = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let c_b64 = URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let signing_input = format!("{h_b64}.{c_b64}");
+        let mac = hmac_sha256::HMAC::mac(signing_input.as_bytes(), [0xaa_u8; 32]);
+        let sig_b64 = URL_SAFE_NO_PAD.encode(mac.as_slice());
+        let token = format!("{signing_input}.{sig_b64}");
+
+        let k_b64 = URL_SAFE_NO_PAD.encode([0xbb_u8; 32]);
+        let jwks_json =
+            format!(r#"{{"keys":[{{"kty":"oct","kid":"k1","alg":"HS256","k":"{k_b64}"}}]}}"#);
+        let jwks = parse_jwks(&jwks_json).unwrap();
+
+        let results = verify_with_jwks(&token, &jwks).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].valid, "wrong oct key must not verify");
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -525,8 +525,16 @@ pub fn decode(token: &str) -> Result<DecodedToken> {
 
 /// Verification key types for JWT
 pub enum VerifyKeyData<'a> {
-    /// Secret for HMAC algorithms
+    /// Secret for HMAC algorithms (text)
     Secret(&'a str),
+    /// Raw secret bytes for HMAC algorithms.
+    ///
+    /// Use this instead of [`VerifyKeyData::Secret`] whenever the key is not
+    /// guaranteed to be valid UTF-8 — e.g. a JWKS `oct` key, whose bytes are
+    /// arbitrary. Forcing such a key through a `&str` (via `from_utf8_lossy`)
+    /// silently replaces invalid bytes with U+FFFD, changing the key and making
+    /// verification of a correctly-signed token fail.
+    SecretBytes(&'a [u8]),
     /// RSA or ECDSA public key in PEM format
     #[allow(dead_code)]
     PublicKeyPem(&'a str),
@@ -725,52 +733,80 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
 
     // Get decoding key based on algorithm and key data
     match &options.key_data {
-        VerifyKeyData::Secret(secret) => {
-            match decoded_token.algorithm {
-                Algorithm::HS256 => {
-                    // Manual signature check
-                    let mut calculated_sig =
-                        hmac_sha256::HMAC::mac(message.as_bytes(), secret.as_bytes());
-                    let sig_matches =
-                        crate::utils::constant_time_eq(&signature, calculated_sig.as_slice());
-                    calculated_sig.zeroize();
-                    if !sig_matches {
-                        return Ok(false); // Signature mismatch
-                    }
-
-                    // If signature is OK, and time validation is requested, perform it.
-                    if options.validate_exp || options.validate_nbf {
-                        let validation = create_validation(Algorithm::HS256, options);
-                        let decoding_key = DecodingKey::from_secret(secret.as_bytes());
-                        match jsonwebtoken::decode::<Value>(token, &decoding_key, &validation) {
-                            Ok(_) => Ok(true), // Token is valid and passed time checks
-                            Err(e) => Err(anyhow::anyhow!(JwtError::from(e.kind().clone()))), // Convert to our JwtError type
-                        }
-                    } else {
-                        Ok(true) // Signature is OK, no time validation requested
-                    }
-                }
-                Algorithm::HS384 | Algorithm::HS512 => {
-                    // For HS384 and HS512, use jsonwebtoken directly which handles signature and time validation.
-                    // Route through handle_verification_result so expired/not-yet-valid tokens surface as
-                    // distinct errors instead of collapsing into a plain `false`, matching the HS256/RSA/EC paths.
-                    let decoding_key = DecodingKey::from_secret(secret.as_bytes());
-                    let validation = create_validation(decoded_token.algorithm, options);
-                    let result = jsonwebtoken::decode::<Value>(token, &decoding_key, &validation);
-                    handle_verification_result(result)
-                }
-                _ => Err(anyhow!(
-                    "Secret key provided but token uses algorithm {:?}. Secret keys can only verify HMAC algorithms (HS256, HS384, HS512)",
-                    decoded_token.algorithm
-                )),
-            }
-        }
+        VerifyKeyData::Secret(secret) => verify_with_secret_bytes(
+            token,
+            &message,
+            &signature,
+            secret.as_bytes(),
+            decoded_token.algorithm,
+            options,
+        ),
+        VerifyKeyData::SecretBytes(secret) => verify_with_secret_bytes(
+            token,
+            &message,
+            &signature,
+            secret,
+            decoded_token.algorithm,
+            options,
+        ),
         VerifyKeyData::PublicKeyPem(pem) => {
             verify_with_public_key_pem(token, pem, decoded_token.algorithm, options)
         }
         VerifyKeyData::PublicKeyDer(der) => {
             verify_with_public_key_der(token, der, decoded_token.algorithm, options)
         }
+    }
+}
+
+/// Verify an HMAC-signed token against a raw secret key (arbitrary bytes).
+///
+/// Shared by [`VerifyKeyData::Secret`] and [`VerifyKeyData::SecretBytes`] so the
+/// key is used verbatim — never routed through a lossy UTF-8 conversion that
+/// would corrupt a binary HMAC key.
+fn verify_with_secret_bytes(
+    token: &str,
+    message: &str,
+    signature: &[u8],
+    secret: &[u8],
+    algorithm: Algorithm,
+    options: &VerifyOptions,
+) -> Result<bool> {
+    match algorithm {
+        Algorithm::HS256 => {
+            // Manual signature check
+            let mut calculated_sig = hmac_sha256::HMAC::mac(message.as_bytes(), secret);
+            let sig_matches =
+                crate::utils::constant_time_eq(signature, calculated_sig.as_slice());
+            calculated_sig.zeroize();
+            if !sig_matches {
+                return Ok(false); // Signature mismatch
+            }
+
+            // If signature is OK, and time validation is requested, perform it.
+            if options.validate_exp || options.validate_nbf {
+                let validation = create_validation(Algorithm::HS256, options);
+                let decoding_key = DecodingKey::from_secret(secret);
+                match jsonwebtoken::decode::<Value>(token, &decoding_key, &validation) {
+                    Ok(_) => Ok(true), // Token is valid and passed time checks
+                    Err(e) => Err(anyhow::anyhow!(JwtError::from(e.kind().clone()))), // Convert to our JwtError type
+                }
+            } else {
+                Ok(true) // Signature is OK, no time validation requested
+            }
+        }
+        Algorithm::HS384 | Algorithm::HS512 => {
+            // For HS384 and HS512, use jsonwebtoken directly which handles signature and time validation.
+            // Route through handle_verification_result so expired/not-yet-valid tokens surface as
+            // distinct errors instead of collapsing into a plain `false`, matching the HS256/RSA/EC paths.
+            let decoding_key = DecodingKey::from_secret(secret);
+            let validation = create_validation(algorithm, options);
+            let result = jsonwebtoken::decode::<Value>(token, &decoding_key, &validation);
+            handle_verification_result(result)
+        }
+        _ => Err(anyhow!(
+            "Secret key provided but token uses algorithm {:?}. Secret keys can only verify HMAC algorithms (HS256, HS384, HS512)",
+            algorithm
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

`jwks --verify` could not verify a token against its own symmetric (`oct`) JWKS key. `verify_with_jwks` converted the key with `String::from_utf8_lossy` before HMAC verification:

```rust
let secret = String::from_utf8_lossy(&secret_bytes);
... VerifyKeyData::Secret(&secret) ...
```

An `oct` key is **arbitrary bytes**. Any non-UTF-8 byte — the common case for a real random HMAC key — is replaced with U+FFFD, which changes the key. A token correctly signed with that key then **fails verification against its own JWKS** (false negative).

## Fix

- Add `VerifyKeyData::SecretBytes(&[u8])` for byte-exact HMAC keys.
- Extract the HMAC verify logic (HS256/384/512) into a shared helper used by both `Secret(&str)` and `SecretBytes(&[u8])`, so the key bytes are used verbatim.
- The JWKS `oct` branch now passes the base64url-decoded key bytes directly instead of a lossy `String`.

## Testing

- New regression tests: a non-UTF-8 (`0xFF…`) `oct` key verifies its correctly-signed token, and a mismatched `oct` key is still rejected (guards against over-accepting).
- Full suite: **538 tests pass**, clippy clean, `cargo fmt --check` clean.