### PR TITLE
fix: prevent crashes and correct wrong security verdicts across subsystems

### DIFF
--- a/src/cmd/crack.rs
+++ b/src/cmd/crack.rs
@@ -563,7 +563,7 @@ fn crack_dictionary(
     const DICT_BATCH_SIZE: usize = 100_000;
 
     let mut word_batch: Vec<String> = Vec::with_capacity(DICT_BATCH_SIZE);
-    let mut line_buf = String::new();
+    let mut line_buf: Vec<u8> = Vec::new();
     let mut bytes_read: u64 = 0;
 
     loop {
@@ -574,14 +574,22 @@ fn crack_dictionary(
         let mut batch_bytes: u64 = 0;
         for _ in 0..DICT_BATCH_SIZE {
             line_buf.clear();
-            let n = match reader.read_line(&mut line_buf) {
+            // Read raw bytes rather than `read_line`, which returns Err on a
+            // non-UTF-8 line. The old `Err(_) => break` aborted the ENTIRE crack at
+            // the first such line, silently skipping the rest of the wordlist and
+            // reporting "not found". Lossy-decode instead so an odd line becomes a
+            // (harmless) candidate and the crack keeps going; only a genuine IO error
+            // stops the loop.
+            let n = match reader.read_until(b'\n', &mut line_buf) {
                 Ok(0) => break, // EOF
                 Ok(n) => n,
-                Err(_) => break,
+                Err(_) => break, // genuine IO error
             };
             batch_bytes += n as u64;
             // Trim trailing newline / carriage return
-            let word = line_buf.trim_end_matches(['\n', '\r']).to_string();
+            let word = String::from_utf8_lossy(&line_buf)
+                .trim_end_matches(['\n', '\r'])
+                .to_string();
             if !word.is_empty() {
                 word_batch.push(word);
             }
@@ -919,11 +927,41 @@ fn crack_target_field(
         }
     };
 
+    // Writing a candidate into a claims field requires the payload to be a JSON
+    // object. If the payload decodes to a JSON array/number/string/bool, indexing it
+    // with a string key (`modified_claims[target_field] = ...`) panics inside
+    // serde_json. Reject such tokens up front with a clear error instead of aborting
+    // the process (the release profile uses panic = "abort").
+    if field_location == "payload" && !claims.is_object() {
+        if emit_output {
+            utils::log_error(format!(
+                "Cannot target payload field '{target_field}': token payload is not a JSON object"
+            ));
+        }
+        return Err(anyhow::anyhow!(
+            "Cannot target payload field '{target_field}': token payload is not a JSON object"
+        ));
+    }
+
     if emit_output {
         utils::log_info(format!(
             "Targeted field cracking: field='{}' location='{}' algorithm='{}'",
             target_field, field_location, alg
         ));
+        // Target-field cracking re-signs each candidate with an EMPTY secret and
+        // compares the result against the token's ORIGINAL signature (see
+        // `run_target_field_crack`). That can only match a token that was itself
+        // signed with an empty secret (or uses alg:none). Against a token signed with
+        // a real secret/key, no candidate can reproduce the signature, so it would
+        // silently run to "not found". Warn up front instead of misleading the user.
+        if !matches!(jwt::verify(options.token, ""), Ok(true)) {
+            utils::log_warning(
+                "Targeted field cracking compares signatures re-signed with an EMPTY secret, so it \
+                 only works against a token signed with an empty secret or alg:none. This token \
+                 carries a real signature, so no field value can reproduce it — the search will be \
+                 inconclusive.",
+            );
+        }
     }
 
     // Generate candidates based on mode
@@ -1040,7 +1078,7 @@ fn crack_target_field(
 
         const TARGET_DICT_BATCH: usize = 100_000;
         let mut word_batch: Vec<String> = Vec::with_capacity(TARGET_DICT_BATCH);
-        let mut line_buf = String::new();
+        let mut line_buf: Vec<u8> = Vec::new();
         let mut bytes_read: u64 = 0;
 
         let loading_pb = if emit_output {
@@ -1056,13 +1094,17 @@ fn crack_target_field(
             let mut batch_bytes: u64 = 0;
             for _ in 0..TARGET_DICT_BATCH {
                 line_buf.clear();
-                let n = match reader.read_line(&mut line_buf) {
+                // Raw-byte read + lossy decode so a non-UTF-8 line doesn't abort the
+                // whole run (see the note in `crack_dictionary`).
+                let n = match reader.read_until(b'\n', &mut line_buf) {
                     Ok(0) => break,
                     Ok(n) => n,
                     Err(_) => break,
                 };
                 batch_bytes += n as u64;
-                let word = line_buf.trim_end_matches(['\n', '\r']).to_string();
+                let word = String::from_utf8_lossy(&line_buf)
+                    .trim_end_matches(['\n', '\r'])
+                    .to_string();
                 if word.is_empty() {
                     continue;
                 }
@@ -1399,6 +1441,44 @@ mod tests {
             result.is_ok(),
             "execute_with_options should not panic with missing wordlist"
         );
+    }
+
+    #[test]
+    fn test_target_field_non_object_payload_errors_not_panics() {
+        use base64::Engine;
+        // Build a well-formed token whose payload is a JSON ARRAY (not an object).
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"[1,2,3]"#);
+        let token = format!("{header}.{payload}.AAAA");
+
+        let target = Some("role".to_string());
+        let options = CrackOptions {
+            token: &token,
+            mode: "dict",
+            wordlist: &None,
+            chars: "abc",
+            preset: &None,
+            concurrency: 1,
+            min: 1,
+            max: 2,
+            power: false,
+            verbose: false,
+            target_field: &target,
+            pattern: &None,
+        };
+
+        // Targeting a payload field on a non-object payload must return an error
+        // rather than panicking on serde_json string-indexing (which, under
+        // panic = "abort", would kill the process).
+        let result = std::panic::catch_unwind(|| crack_target_field(&options, "role", false));
+        match result {
+            Ok(inner) => assert!(
+                inner.is_err(),
+                "expected an Err for a non-object payload, got Ok"
+            ),
+            Err(_) => panic!("crack_target_field panicked on a non-object payload"),
+        }
     }
 
     #[test]

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -320,33 +320,63 @@ fn scan_jwe_token(token: &str) -> Result<ScanReport> {
         }
     });
 
-    // IV length (GCM wants a 96-bit / 12-byte nonce).
-    if !decoded.iv.is_empty() {
-        if let Ok(iv) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&decoded.iv) {
-            if iv.len() < 12 {
-                results.push(VulnerabilityResult {
-                    name: "IV".to_string(),
-                    vulnerable: true,
-                    details: format!("IV is {} bytes — GCM expects a 12-byte nonce", iv.len()),
-                    severity: Severity::Medium,
-                });
-            }
+    // IV length (GCM wants a 96-bit / 12-byte nonce). An empty IV is worse than a
+    // short one — it means no nonce at all — so flag it explicitly rather than
+    // skipping the check (the `!is_empty()` guard previously let an empty IV pass
+    // silently).
+    if decoded.iv.is_empty() {
+        results.push(VulnerabilityResult {
+            name: "IV".to_string(),
+            vulnerable: true,
+            details: "IV is missing/empty — encryption without a nonce is broken".to_string(),
+            severity: Severity::High,
+        });
+    } else if let Ok(iv) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&decoded.iv) {
+        if iv.len() < 12 {
+            results.push(VulnerabilityResult {
+                name: "IV".to_string(),
+                vulnerable: true,
+                details: format!("IV is {} bytes — GCM expects a 12-byte nonce", iv.len()),
+                severity: Severity::Medium,
+            });
         }
     }
 
-    // Auth tag length.
-    if !decoded.tag.is_empty() {
-        if let Ok(tag) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&decoded.tag) {
-            if tag.len() < 16 {
-                results.push(VulnerabilityResult {
-                    name: "Authentication Tag".to_string(),
-                    vulnerable: true,
-                    details: format!("Auth tag is {} bytes — expected at least 16", tag.len()),
-                    severity: Severity::Medium,
-                });
-            }
+    // Auth tag length. An empty tag means the ciphertext is unauthenticated, so flag
+    // it explicitly instead of skipping the check.
+    if decoded.tag.is_empty() {
+        results.push(VulnerabilityResult {
+            name: "Authentication Tag".to_string(),
+            vulnerable: true,
+            details: "Authentication tag is missing/empty — ciphertext is unauthenticated"
+                .to_string(),
+            severity: Severity::High,
+        });
+    } else if let Ok(tag) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(&decoded.tag) {
+        if tag.len() < 16 {
+            results.push(VulnerabilityResult {
+                name: "Authentication Tag".to_string(),
+                vulnerable: true,
+                details: format!("Auth tag is {} bytes — expected at least 16", tag.len()),
+                severity: Severity::Medium,
+            });
         }
     }
+
+    // JOSE header-injection checks apply to a JWE recipient just as they do to a JWS
+    // verifier: RFC 7516 §4.1.4–4.1.6 defines `jku`, `jwk`, `kid`, `x5u` (and `crit`)
+    // as JWE header parameters, and the SSRF / key-substitution / path-traversal
+    // attacks they enable are identical. These checks read only the header, so run
+    // them over a synthetic view of the JWE's (fully parsed) protected header.
+    let header_view = jwt::DecodedToken {
+        header: decoded.header.clone(),
+        claims: serde_json::Value::Null,
+        algorithm: jsonwebtoken::Algorithm::HS256, // sentinel; header-only checks ignore it
+    };
+    results.push(check_kid_vulnerabilities(&header_view)?);
+    results.push(check_jku_x5u_vulnerabilities(&header_view)?);
+    results.push(check_jwk_header(&header_view)?);
+    results.push(check_crit_header(&header_view)?);
 
     let summary = summarize_results(&results);
     Ok(ScanReport {
@@ -705,19 +735,47 @@ fn check_weak_secret(
 
     let secrets_to_test: Vec<String> = if let Some(ref wordlist_path) = options.wordlist {
         // Read from wordlist file (limited to max_crack_attempts)
-        if let Ok(file) = std::fs::File::open(wordlist_path) {
-            use std::io::{BufRead, BufReader};
-            let reader = BufReader::new(file);
-            reader
-                .lines()
-                .map_while(Result::ok)
-                .take(options.max_crack_attempts)
-                .collect()
-        } else {
-            common_secrets.iter().map(|s| s.to_string()).collect()
+        match std::fs::File::open(wordlist_path) {
+            Ok(file) => {
+                use std::io::{BufRead, BufReader};
+                let reader = BufReader::new(file);
+                // Examine at most `max_crack_attempts` lines, skipping individual
+                // undecodable (non-UTF-8) lines instead of stopping at the first one.
+                // The previous `map_while(Result::ok)` STOPPED at the first such line,
+                // so a wordlist whose first line wasn't valid UTF-8 tested zero secrets
+                // and the token was wrongly reported "no weak secret found". Bounding
+                // on the raw line count with `take` (before `flatten` drops the Errs)
+                // also guarantees termination on a pathologically erroring reader.
+                reader
+                    .lines()
+                    .take(options.max_crack_attempts)
+                    .flatten()
+                    .collect()
+            }
+            Err(e) => {
+                // Don't silently pretend the wordlist was used. Warn, then fall back
+                // to the built-in list so a bad `--wordlist` path is visible instead
+                // of masquerading as a clean result.
+                utils::log_warning(format!(
+                    "Could not open wordlist {}: {} — falling back to built-in common secrets",
+                    wordlist_path.display(),
+                    e
+                ));
+                common_secrets
+                    .iter()
+                    .take(options.max_crack_attempts)
+                    .map(|s| s.to_string())
+                    .collect()
+            }
         }
     } else {
-        common_secrets.iter().map(|s| s.to_string()).collect()
+        // Honor max_crack_attempts here too; it was previously ignored unless a
+        // wordlist was supplied.
+        common_secrets
+            .iter()
+            .take(options.max_crack_attempts)
+            .map(|s| s.to_string())
+            .collect()
     };
 
     let mut found_secret: Option<String> = None;
@@ -765,10 +823,23 @@ fn check_algorithm_confusion(
         .unwrap_or_else(|| format!("{:?}", decoded.algorithm));
     let alg_upper = alg_str.to_uppercase();
 
-    let uses_asymmetric = alg_upper.starts_with("RS")
-        || alg_upper.starts_with("ES")
-        || alg_upper.starts_with("PS")
-        || alg_upper == "EDDSA";
+    // Match the exact JWS asymmetric signing algorithms. A `starts_with("RS")`-style
+    // prefix test also matched JWE *key-management* algorithms such as `RSA-OAEP` and
+    // `RSA1_5`, so a (malformed) 3-segment token carrying one of those was wrongly
+    // flagged as vulnerable to RS256->HS256 signature confusion.
+    let uses_asymmetric = matches!(
+        alg_upper.as_str(),
+        "RS256"
+            | "RS384"
+            | "RS512"
+            | "ES256"
+            | "ES384"
+            | "ES512"
+            | "PS256"
+            | "PS384"
+            | "PS512"
+            | "EDDSA"
+    );
 
     let result = if uses_asymmetric {
         VulnerabilityResult {
@@ -812,6 +883,16 @@ fn check_token_expiration(decoded: &jwt::DecodedToken) -> Result<VulnerabilityRe
         .collect();
     if !missing_claims.is_empty() {
         issues.push(format!("Missing '{}'", missing_claims.join("', '")));
+    }
+
+    // A present-but-non-numeric `exp` (null, string, bool, object, ...) is not a
+    // usable expiration. The NumericDate reader below returns `None` for it, so
+    // without an explicit check such a token was silently reported as having proper
+    // expiration — an expiry that no compliant verifier can enforce.
+    if let Some(exp_val) = decoded.claims.get("exp") {
+        if utils::numeric_date_seconds(exp_val).is_none() {
+            issues.push("'exp' is present but not a numeric date".to_string());
+        }
     }
 
     // Evaluate expiry with a NumericDate reader that accepts float values too
@@ -2325,6 +2406,112 @@ mod tests {
                 && r.vulnerable
                 && r.severity == Severity::High),
             "CBC enc must be High (padding oracle)"
+        );
+    }
+
+    #[test]
+    fn test_scan_jwe_runs_header_injection_checks() {
+        use base64::Engine;
+        // A JWE whose protected header carries jku (SSRF), a traversal kid, and an
+        // embedded jwk. These header-injection risks must be reported for JWEs too,
+        // not just JWSs.
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            br#"{"alg":"dir","enc":"A256GCM","jku":"http://attacker.example/keys.json","kid":"../../../../etc/passwd","jwk":{"kty":"oct"}}"#,
+        );
+        let jwe = format!("{header}..aXYaXYaXYaXYaXYa.Y3Q.dGFndGFndGFndGFn");
+        let report = scan_jwe_token(&jwe).expect("scan jwe");
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|r| r.name.contains("jku") || r.name.to_lowercase().contains("jku/x5u")),
+            "JWE with jku must surface a jku/x5u finding: {:?}",
+            report.results.iter().map(|r| &r.name).collect::<Vec<_>>()
+        );
+        assert!(
+            report.results.iter().any(|r| r.name.to_lowercase().contains("kid") && r.vulnerable),
+            "JWE with a traversal kid must be flagged"
+        );
+        assert!(
+            report.results.iter().any(|r| r.name.to_lowercase().contains("jwk") && r.vulnerable),
+            "JWE with an embedded jwk must be flagged"
+        );
+    }
+
+    #[test]
+    fn test_scan_jwe_flags_empty_iv_and_tag() {
+        use base64::Engine;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"alg":"dir","enc":"A256GCM"}"#);
+        // Five segments (header.encrypted_key.iv.ciphertext.tag) with an EMPTY
+        // encrypted_key, EMPTY IV and EMPTY tag: "HDR" + "." + "" + "." + "" + "." +
+        // "Y3Q" + "." + "" => "HDR...Y3Q."
+        let jwe = format!("{header}...Y3Q.");
+        assert_eq!(jwe.split('.').count(), 5, "must be a 5-segment JWE");
+        let report = scan_jwe_token(&jwe).expect("scan jwe");
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|r| r.name == "IV" && r.vulnerable),
+            "empty IV must be flagged"
+        );
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|r| r.name == "Authentication Tag" && r.vulnerable),
+            "empty auth tag must be flagged"
+        );
+    }
+
+    #[test]
+    fn test_check_token_expiration_non_numeric_exp_flagged() {
+        // A present-but-non-numeric exp is not a usable expiration and must be flagged
+        // rather than treated as a proper expiry claim.
+        for bad in [json!("soon"), json!(null), json!(true), json!({"x": 1})] {
+            let decoded = jwt::DecodedToken {
+                header: std::collections::HashMap::new(),
+                claims: json!({ "exp": bad, "nbf": 1, "iat": 1 }),
+                algorithm: jsonwebtoken::Algorithm::HS256,
+            };
+            let r = check_token_expiration(&decoded).unwrap();
+            assert!(
+                r.vulnerable && r.details.contains("not a numeric date"),
+                "non-numeric exp {:?} must be flagged, got: {}",
+                r.details,
+                r.details
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_weak_secret_skips_non_utf8_wordlist_line() {
+        use std::io::Write;
+        // Token signed with a known weak secret.
+        let secret = "letmein";
+        let token = create_test_token("HS256", secret);
+        let decoded = jwt::decode(&token).unwrap();
+
+        // Wordlist whose FIRST line is invalid UTF-8, then the real secret. The old
+        // `map_while(Result::ok)` stopped at the first line and tested nothing;
+        // `filter_map` must skip it and still find "letmein".
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(&[0xff, 0xfe, 0x00, b'\n']).unwrap();
+        writeln!(f, "notit").unwrap();
+        writeln!(f, "{secret}").unwrap();
+        f.flush().unwrap();
+        let path = f.path().to_path_buf();
+
+        let options = ScanOptions {
+            wordlist: Some(&path),
+            ..Default::default()
+        };
+        let result = check_weak_secret(&token, &decoded, &options).unwrap();
+        assert!(
+            result.vulnerable && result.details.contains(secret),
+            "weak secret behind a non-UTF-8 line must still be found: {}",
+            result.details
         );
     }
 

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -425,7 +425,19 @@ fn crack_dict(token: &str, wordlist_path: &PathBuf) -> anyhow::Result<Option<Str
     let file = File::open(wordlist_path)?;
     let reader = BufReader::new(file).take(MAX_WORDLIST_BYTES);
 
-    Ok(crack_words(token, reader.lines().map_while(Result::ok)))
+    // `split(b'\n')` reads raw bytes, so a non-UTF-8 line is lossy-decoded into a
+    // candidate rather than terminating the iterator early (as `lines()` +
+    // `map_while(Result::ok)` did, silently skipping the rest of the wordlist). The
+    // outer `.take(MAX_WORDLIST_BYTES)` bounds total bytes read.
+    let words = reader
+        .split(b'\n')
+        .map_while(Result::ok)
+        .map(|line| {
+            String::from_utf8_lossy(&line)
+                .trim_end_matches('\r')
+                .to_string()
+        });
+    Ok(crack_words(token, words))
 }
 
 /// Helper function to crack JWT using brute force

--- a/src/cmd/shell/capture.rs
+++ b/src/cmd/shell/capture.rs
@@ -1,4 +1,5 @@
 use std::io::Read;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, TryLockError};
 
 use ansi_to_tui::IntoText;
@@ -9,6 +10,39 @@ use ratatui::text::Text;
 /// `crack` thread and another command) race on the same OS fds: the loser silently
 /// runs with no redirect, leaking raw output onto the TUI and losing its own output.
 static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Number of captures currently redirecting the process-global stdout/stderr.
+///
+/// `gag::BufferRedirect` redirects the *process* stdout, which the ratatui/crossterm
+/// TUI also writes to. If the main render loop draws a frame while a background
+/// `crack`/`scan` capture is active, the frame's escape sequences are swallowed into
+/// the capture buffer instead of reaching the terminal — freezing the TUI and
+/// corrupting the captured command output. The render loop consults
+/// [`capture_in_progress`] and skips drawing while this is non-zero.
+static ACTIVE_CAPTURES: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether any capture is currently redirecting global stdout/stderr. The shell's
+/// render loop must not draw while this is true (see [`ACTIVE_CAPTURES`]).
+pub fn capture_in_progress() -> bool {
+    ACTIVE_CAPTURES.load(Ordering::SeqCst) > 0
+}
+
+/// RAII marker that keeps [`ACTIVE_CAPTURES`] incremented for the lifetime of a
+/// capture, covering every early-return path.
+struct ActiveGuard;
+
+impl ActiveGuard {
+    fn new() -> Self {
+        ACTIVE_CAPTURES.fetch_add(1, Ordering::SeqCst);
+        ActiveGuard
+    }
+}
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        ACTIVE_CAPTURES.fetch_sub(1, Ordering::SeqCst);
+    }
+}
 
 /// Result of capturing stdout/stderr from a command
 #[allow(dead_code)]
@@ -23,6 +57,11 @@ pub fn capture_command_output<F>(f: F) -> CapturedOutput
 where
     F: FnOnce(),
 {
+    // Signal (for the whole capture, via RAII) that global stdout is being
+    // redirected, so the TUI render loop pauses drawing and its frames aren't
+    // swallowed into the capture buffer.
+    let _active = ActiveGuard::new();
+
     // Hold the global capture lock for the entire redirect + restore. If another
     // capture is already active we refuse rather than block (avoiding a UI freeze)
     // or corrupt the screen (avoiding the silent no-redirect fallback below).

--- a/src/cmd/shell/completion.rs
+++ b/src/cmd/shell/completion.rs
@@ -22,7 +22,15 @@ impl CompletionState {
     /// Apply the currently selected candidate to the input, returning (new_input, new_cursor_pos)
     pub fn apply(&self, input: &str) -> (String, usize) {
         let replacement = &self.candidates[self.selected_index];
-        let before = &input[..self.prefix_start];
+        // Defensive: floor `prefix_start` to a valid char boundary within `input` so
+        // a miscomputed byte offset can never trigger a non-char-boundary slice
+        // panic (the release profile uses panic = "abort", which would kill the whole
+        // shell session).
+        let mut start = self.prefix_start.min(input.len());
+        while start > 0 && !input.is_char_boundary(start) {
+            start -= 1;
+        }
+        let before = &input[..start];
         let new_input = format!("{before}{replacement} ");
         let new_cursor = new_input.len();
         (new_input, new_cursor)
@@ -50,9 +58,20 @@ impl CompletionState {
 /// Compute completions for the given input at the given cursor position.
 /// Returns None if no completions are available.
 pub fn compute_completions(input: &str, cursor_pos: usize) -> Option<CompletionState> {
-    let line_up_to_cursor = &input[..cursor_pos.min(input.len())];
+    // Clamp the cursor down to a valid char boundary so neither the slice below nor
+    // the `end - prefix.len()` offsets can land inside a multi-byte character.
+    let mut end = cursor_pos.min(input.len());
+    while end > 0 && !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    let line_up_to_cursor = &input[..end];
     let parts: Vec<&str> = line_up_to_cursor.split_whitespace().collect();
-    let at_word_boundary = line_up_to_cursor.ends_with(' ');
+    // `split_whitespace` splits on ALL Unicode whitespace, so the word-boundary test
+    // must use the same predicate. Checking only for an ASCII ' ' let an input ending
+    // in e.g. a non-breaking space (U+00A0) or ideographic space (U+3000) take the
+    // "still typing a word" branch, where `end - prefix.len()` then pointed inside
+    // that multi-byte whitespace char and `apply()` panicked slicing there.
+    let at_word_boundary = line_up_to_cursor.ends_with(char::is_whitespace);
 
     let (prefix_start, candidates) = match parts.len() {
         0 => {
@@ -68,12 +87,12 @@ pub fn compute_completions(input: &str, cursor_pos: usize) -> Option<CompletionS
                 .filter(|c| c.starts_with(prefix))
                 .map(|c| c.to_string())
                 .collect();
-            (cursor_pos - prefix.len(), candidates)
+            (end - prefix.len(), candidates)
         }
         1 if at_word_boundary && parts[0] == "set" => {
             // After "set " — suggest keys
             let candidates: Vec<String> = SET_KEYS.iter().map(|k| k.to_string()).collect();
-            (cursor_pos, candidates)
+            (end, candidates)
         }
         2 if !at_word_boundary && parts[0] == "set" => {
             // Typing set key — match keys
@@ -83,12 +102,12 @@ pub fn compute_completions(input: &str, cursor_pos: usize) -> Option<CompletionS
                 .filter(|k| k.starts_with(prefix))
                 .map(|k| k.to_string())
                 .collect();
-            (cursor_pos - prefix.len(), candidates)
+            (end - prefix.len(), candidates)
         }
         2 if at_word_boundary && parts[0] == "set" && parts[1] == "algorithm" => {
             // After "set algorithm " — suggest algorithms
             let candidates: Vec<String> = ALGORITHMS.iter().map(|a| a.to_string()).collect();
-            (cursor_pos, candidates)
+            (end, candidates)
         }
         3 if !at_word_boundary && parts[0] == "set" && parts[1] == "algorithm" => {
             // Typing algorithm name
@@ -98,7 +117,7 @@ pub fn compute_completions(input: &str, cursor_pos: usize) -> Option<CompletionS
                 .filter(|a| a.starts_with(prefix))
                 .map(|a| a.to_string())
                 .collect();
-            (cursor_pos - prefix.len(), candidates)
+            (end - prefix.len(), candidates)
         }
         _ => return None,
     };
@@ -173,6 +192,31 @@ mod tests {
         let (new_input, new_cursor) = state.apply("dec");
         assert_eq!(new_input, "decode ");
         assert_eq!(new_cursor, 7);
+    }
+
+    #[test]
+    fn test_multibyte_whitespace_does_not_panic() {
+        // A short word followed by a multi-byte whitespace char used to compute a
+        // prefix offset landing inside that char, panicking in apply().
+        for ws in ["\u{3000}", "\u{a0}", "\u{2003}"] {
+            let input = format!("d{ws}");
+            let cursor = input.len();
+            // Must not panic; whichever branch it takes, apply() must be boundary-safe.
+            if let Some(state) = compute_completions(&input, cursor) {
+                let (_new_input, _new_cursor) = state.apply(&input);
+            }
+        }
+    }
+
+    #[test]
+    fn test_multibyte_word_completion_boundary_safe() {
+        // Multi-byte content before the cursor must never yield an off-boundary slice.
+        let input = "décode"; // é is 2 bytes
+        let state = compute_completions(input, input.len());
+        if let Some(state) = state {
+            let (new_input, _cursor) = state.apply(input);
+            assert!(new_input.is_char_boundary(0));
+        }
     }
 
     #[test]

--- a/src/cmd/shell/mod.rs
+++ b/src/cmd/shell/mod.rs
@@ -77,6 +77,9 @@ pub struct App {
     pub should_quit: bool,
 }
 
+/// Upper bound on retained shell output lines (see [`App::enforce_output_cap`]).
+const MAX_OUTPUT_LINES: usize = 5000;
+
 impl App {
     fn new() -> Self {
         Self {
@@ -164,6 +167,21 @@ impl App {
         self.scroll_offset = total;
     }
 
+    /// Drop the oldest output lines once the buffer exceeds [`MAX_OUTPUT_LINES`].
+    ///
+    /// Without a cap the output buffer grows without bound over a long session and,
+    /// because the whole `Text` is cloned every frame in the renderer, both memory
+    /// use and per-frame cost climb indefinitely.
+    fn enforce_output_cap(&mut self) {
+        let len = self.output_lines.lines.len();
+        if len > MAX_OUTPUT_LINES {
+            let drop = len - MAX_OUTPUT_LINES;
+            self.output_lines.lines.drain(0..drop);
+            // Keep auto-scroll anchored near the (new) bottom.
+            self.scroll_offset = self.scroll_offset.saturating_sub(drop);
+        }
+    }
+
     fn visible_height(&self) -> usize {
         // Approximate; actual value depends on terminal size.
         // The UI renderer will clamp this.
@@ -211,7 +229,17 @@ fn run_tui() -> io::Result<()> {
 
     // Main event loop
     loop {
-        terminal.draw(|frame| ui::render(frame, &app))?;
+        // Bound the output buffer before each frame so a long session can't grow it
+        // without limit (the whole buffer is cloned per frame in the renderer).
+        app.enforce_output_cap();
+        // Don't draw while a background crack/scan is redirecting global stdout —
+        // our frame's escape sequences would be captured into its buffer, freezing
+        // the TUI and corrupting the captured output. The last frame (e.g. "Cracking
+        // in background...") stays on screen until the capture finishes; input is
+        // still polled below so the shell stays responsive.
+        if !capture::capture_in_progress() {
+            terminal.draw(|frame| ui::render(frame, &app))?;
+        }
 
         // Check for async results (non-blocking)
         if let Ok(result) = rx.try_recv() {
@@ -326,7 +354,12 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
             let line = app.input.trim().to_string();
             if !line.is_empty() {
                 app.push_command_echo(&line);
-                app.history.add(&line);
+                // Never persist commands that carry secrets (`set secret ...`,
+                // `set private_key ...`) — the history is written to a plaintext file
+                // under the user's config dir.
+                if !is_sensitive_command(&line) {
+                    app.history.add(&line);
+                }
                 handle_command(&line, app, tx);
                 app.input.clear();
                 app.cursor_position = 0;
@@ -415,6 +448,19 @@ fn handle_key_event(key: KeyEvent, app: &mut App, tx: &mpsc::Sender<AsyncResult>
 // ---------- Command dispatch ----------
 
 const SET_KEYS: &[&str] = &["token", "secret", "algorithm", "private_key", "wordlist"];
+
+/// Whether a shell command line carries a secret that must not be written to the
+/// plaintext history file (e.g. `set secret <value>` or `set private_key <path>`).
+fn is_sensitive_command(line: &str) -> bool {
+    let mut parts = line.split_whitespace();
+    if parts.next().map(|c| c.eq_ignore_ascii_case("set")) != Some(true) {
+        return false;
+    }
+    matches!(
+        parts.next().map(|k| k.to_ascii_lowercase()).as_deref(),
+        Some("secret") | Some("private_key")
+    )
+}
 
 fn handle_command(line: &str, app: &mut App, tx: &mpsc::Sender<AsyncResult>) {
     let parts: Vec<&str> = line.splitn(3, ' ').collect();
@@ -791,6 +837,36 @@ fn handle_scan(parts: &[&str], app: &mut App, tx: &mpsc::Sender<AsyncResult>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_sensitive_command() {
+        // Secret-bearing commands must be kept out of the plaintext history file.
+        assert!(is_sensitive_command("set secret hunter2"));
+        assert!(is_sensitive_command("  SET   Secret   hunter2  "));
+        assert!(is_sensitive_command("set private_key /path/to/key.pem"));
+        // Everything else is fine to record.
+        assert!(!is_sensitive_command("set token eyJ..."));
+        assert!(!is_sensitive_command("set algorithm HS256"));
+        assert!(!is_sensitive_command("decode eyJ..."));
+        assert!(!is_sensitive_command("set"));
+        assert!(!is_sensitive_command(""));
+    }
+
+    #[test]
+    fn test_enforce_output_cap_bounds_buffer() {
+        let mut app = App::new();
+        for i in 0..(MAX_OUTPUT_LINES + 500) {
+            app.output_lines
+                .lines
+                .push(ratatui::text::Line::raw(format!("line {i}")));
+        }
+        app.enforce_output_cap();
+        assert_eq!(app.output_lines.lines.len(), MAX_OUTPUT_LINES);
+        // Oldest lines are the ones dropped; the newest must remain.
+        let last = app.output_lines.lines.last().unwrap();
+        let text: String = last.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, format!("line {}", MAX_OUTPUT_LINES + 500 - 1));
+    }
 
     #[test]
     fn test_session_default() {

--- a/src/cmd/shell/ui.rs
+++ b/src/cmd/shell/ui.rs
@@ -30,14 +30,19 @@ pub fn render(frame: &mut Frame, app: &App) {
         render_completion_popup(frame, state, chunks[2]);
     }
 
-    // Set cursor position in input area
+    // Set cursor position in input area. Use saturating arithmetic throughout: on a
+    // very narrow terminal `chunks[2].width` can be 0 or 1, so `x + width - 2` would
+    // underflow u16 (a debug panic / release wrap), and the additive terms could
+    // otherwise overflow u16 for a pathologically long input line.
     let prompt = app.session.prompt();
-    let cursor_x = chunks[2].x + 1 + prompt.len() as u16 + app.cursor_position as u16;
-    let cursor_y = chunks[2].y + 1;
-    frame.set_cursor_position(Position::new(
-        cursor_x.min(chunks[2].x + chunks[2].width - 2),
-        cursor_y,
-    ));
+    let cursor_x = chunks[2]
+        .x
+        .saturating_add(1)
+        .saturating_add(prompt.len() as u16)
+        .saturating_add(app.cursor_position as u16);
+    let cursor_y = chunks[2].y.saturating_add(1);
+    let max_x = chunks[2].x.saturating_add(chunks[2].width).saturating_sub(2);
+    frame.set_cursor_position(Position::new(cursor_x.min(max_x), cursor_y));
 }
 
 fn render_title_bar(frame: &mut Frame, app: &App, area: Rect) {

--- a/src/jwks/mod.rs
+++ b/src/jwks/mod.rs
@@ -60,8 +60,18 @@ pub struct SpoofedJwks {
     pub signed_token: Option<String>,
 }
 
+/// Maximum JWKS response body (bytes) that [`fetch_jwks`] will buffer.
+///
+/// A JWKS is normally a few kilobytes. Without a cap, `response.json()` buffers the
+/// entire body into memory, so a hostile or misconfigured endpoint could return a
+/// multi-gigabyte body and exhaust memory. 5 MiB is far more than any legitimate key
+/// set needs.
+const MAX_JWKS_BYTES: u64 = 5 * 1024 * 1024;
+
 /// Fetch a JWKS from a remote URL
 pub fn fetch_jwks(url: &str) -> Result<JwkSet> {
+    use std::io::Read;
+
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()?;
@@ -80,8 +90,23 @@ pub fn fetch_jwks(url: &str) -> Result<JwkSet> {
         ));
     }
 
-    let jwks: JwkSet = response
-        .json()
+    // Bound the buffered body. reqwest's blocking `Response` implements `Read`;
+    // `take` caps how many bytes are read before parsing so an oversized response is
+    // rejected instead of exhausting memory.
+    let mut body = Vec::new();
+    response
+        .take(MAX_JWKS_BYTES + 1)
+        .read_to_end(&mut body)
+        .map_err(|e| anyhow!("Failed to read JWKS response from {}: {}", url, e))?;
+    if body.len() as u64 > MAX_JWKS_BYTES {
+        return Err(anyhow!(
+            "JWKS response from {} exceeds maximum allowed size of {} bytes",
+            url,
+            MAX_JWKS_BYTES
+        ));
+    }
+
+    let jwks: JwkSet = serde_json::from_slice(&body)
         .map_err(|e| anyhow!("Failed to parse JWKS response: {}", e))?;
 
     Ok(jwks)

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -213,7 +213,17 @@ pub fn encode_with_options(claims: &Value, options: &EncodeOptions) -> Result<St
         "ES256" => Algorithm::ES256,
         "ES384" => Algorithm::ES384,
         "ES512" => {
-            // ES512 requires josekit as jsonwebtoken doesn't support it
+            // ES512 is signed via josekit (jsonwebtoken can't represent it) and takes
+            // an early return here — BEFORE the `compress_payload` handling below. So
+            // requesting compression with ES512 would silently produce an
+            // *uncompressed* token while callers still reported `compress: true`.
+            // Compression is only implemented for HS256 (see `encode_compressed_jwt`),
+            // so reject it explicitly instead of quietly ignoring the flag.
+            if options.compress_payload {
+                return Err(anyhow!(
+                    "Payload compression is not supported for ES512 (only HS256)"
+                ));
+            }
             return encode_with_josekit_jwt(claims, options, "ES512");
         }
         "PS256" => Algorithm::PS256,
@@ -580,6 +590,21 @@ pub enum VerifyKeyData<'a> {
     PublicKeyDer(&'a [u8]),
 }
 
+/// Whether `key_data` carries actual key material.
+///
+/// An empty secret or empty key blob is treated as "no key". Used to tell apart
+/// merely *inspecting* an unsigned `none` token (no key supplied) from an attempt
+/// to *verify* it against a real key — the latter must never succeed (alg:none
+/// bypass). See [`verify_with_options`].
+fn verify_key_is_present(key_data: &VerifyKeyData) -> bool {
+    match key_data {
+        VerifyKeyData::Secret(s) => !s.is_empty(),
+        VerifyKeyData::SecretBytes(b) => !b.is_empty(),
+        VerifyKeyData::PublicKeyPem(s) => !s.is_empty(),
+        VerifyKeyData::PublicKeyDer(b) => !b.is_empty(),
+    }
+}
+
 /// Advanced verification options for JWT token
 pub struct VerifyOptions<'a> {
     /// The key data (secret or public key)
@@ -717,12 +742,19 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
     // Try to decode the token without validation
     let decoded_token = decode(token)?;
 
-    // Handle "none" algorithm specially
+    // Handle "none" algorithm specially. A `none` token carries NO signature, so it
+    // can never be cryptographically verified against a key. Returning `Ok(true)`
+    // unconditionally here is the classic alg:none bypass: callers that supply a real
+    // secret/key (the crack loops, `jwks verify`, the REST/MCP crack endpoints) would
+    // treat an unsigned token as validly signed — "finding" a bogus secret or
+    // reporting every JWKS key as VALID. Only report `true` when NO key material was
+    // supplied, i.e. the caller is merely inspecting an unsigned token (the `verify`
+    // command passes an empty secret for that case). When a key IS present, an
+    // unsigned token is not validly signed against it, so return `false`.
     if let Some(alg) = decoded_token.header.get("alg") {
         if let Some(alg_str) = alg.as_str() {
-            if alg_str.to_uppercase() == "NONE" {
-                // For "none" algorithm, we don't verify any signature
-                return Ok(true);
+            if alg_str.eq_ignore_ascii_case("none") {
+                return Ok(!verify_key_is_present(&options.key_data));
             }
         }
     }
@@ -754,10 +786,17 @@ pub fn verify_with_options(token: &str, options: &VerifyOptions) -> Result<bool>
         ));
     }
 
-    // Split the token
+    // Split the token. A JWS in compact serialization is EXACTLY three segments
+    // (`header.payload.signature`). Accepting `>= 3` let a malformed 4+-segment
+    // token through: the extra segments were silently ignored and, if `header.
+    // payload.signature` happened to be a valid token, the whole malformed string
+    // was reported as validly signed. Require exactly three segments.
     let parts: Vec<&str> = token.split('.').collect();
-    if parts.len() < 3 {
-        return Err(anyhow!("Invalid token format for verification"));
+    if parts.len() != 3 {
+        return Err(anyhow!(
+            "Invalid token format for verification: expected 3 segments, found {}",
+            parts.len()
+        ));
     }
 
     // Get message and signature parts
@@ -2102,20 +2141,66 @@ mod tests {
         let token_str = encode_with_options(&claims, &options_encode)
             .expect("Encoding 'none' algorithm token failed");
 
-        let options_verify = VerifyOptions {
-            // KeyData is irrelevant for "none" algorithm as per current verify_with_options logic
-            key_data: VerifyKeyData::Secret("any_secret_is_ignored_for_none"),
+        // Inspection: with NO key supplied (empty secret), an unsigned 'none' token
+        // is trivially "valid" — nothing to verify.
+        let inspect = VerifyOptions {
+            key_data: VerifyKeyData::Secret(""),
             ..Default::default()
         };
-        let result = verify_with_options(&token_str, &options_verify);
-        assert!(
-            result.is_ok(),
-            "Verification of 'none' token erred: {:?}",
-            result.err()
+        assert_eq!(
+            verify_with_options(&token_str, &inspect).ok(),
+            Some(true),
+            "inspecting an unsigned 'none' token with no key should be Ok(true)"
         );
+
+        // Security: when a real secret IS supplied, a 'none' token carries no
+        // signature and must NOT be reported as validly signed against that secret —
+        // this is the classic alg:none bypass.
+        let with_secret = VerifyOptions {
+            key_data: VerifyKeyData::Secret("any_secret"),
+            ..Default::default()
+        };
+        assert_eq!(
+            verify_with_options(&token_str, &with_secret).ok(),
+            Some(false),
+            "verifying a 'none' token against a real secret must be Ok(false)"
+        );
+
+        // Same guard for a supplied key blob and raw secret bytes.
+        let with_bytes = VerifyOptions {
+            key_data: VerifyKeyData::SecretBytes(b"any_secret"),
+            ..Default::default()
+        };
+        assert_eq!(
+            verify_with_options(&token_str, &with_bytes).ok(),
+            Some(false),
+            "verifying a 'none' token against real key bytes must be Ok(false)"
+        );
+    }
+
+    #[test]
+    fn test_verify_rejects_extra_segments() {
+        // A validly-signed 3-segment HS256 token...
+        let claims = json!({"user": "seg"});
+        let options_encode = EncodeOptions {
+            algorithm: "HS256",
+            key_data: KeyData::Secret("topsecret"),
+            header_params: None,
+            compress_payload: false,
+        };
+        let token = encode_with_options(&claims, &options_encode).expect("encode");
+        let opts = VerifyOptions {
+            key_data: VerifyKeyData::Secret("topsecret"),
+            ..Default::default()
+        };
+        assert_eq!(verify_with_options(&token, &opts).ok(), Some(true));
+
+        // ...must be rejected outright once a 4th segment is appended, rather than
+        // silently ignoring the extra segment and reporting the token as valid.
+        let tampered = format!("{token}.extrasegment");
         assert!(
-            result.unwrap(),
-            "Verification of 'none' token returned false"
+            verify_with_options(&tampered, &opts).is_err(),
+            "a 4-segment token must be rejected as malformed"
         );
     }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -116,10 +116,19 @@ fn e2e_none_algorithm_token() {
         Some("none")
     );
     assert_eq!(decoded.claims["sub"], "admin");
-    // The library `verify` accepts `alg:none` tokens regardless of the secret —
-    // this is exactly the alg:none acceptance pitfall jwt-hack helps surface, so
-    // we pin the behavior here rather than assume signature enforcement.
-    assert!(jwt::verify(&token, "anything").expect("verify none"));
+    // A `none` token carries no signature. When a real secret is supplied, `verify`
+    // must NOT report it as validly signed — otherwise the tool itself would fall for
+    // the classic alg:none bypass (and its crack/JWKS paths would "find" bogus
+    // secrets / mark unsigned tokens VALID). With NO key (empty secret), the token is
+    // trivially accepted for inspection.
+    assert!(
+        !jwt::verify(&token, "anything").expect("verify none w/ secret"),
+        "alg:none must not verify against a provided secret"
+    );
+    assert!(
+        jwt::verify(&token, "").expect("verify none w/o key"),
+        "alg:none with no key is accepted for inspection"
+    );
 }
 
 /// Scenario 5: JWE (direct symmetric key) encrypt -> detect -> decrypt.


### PR DESCRIPTION
## Summary

A hardening pass focused on **crash prevention** and **incorrect behavior**, driven by a multi-agent stability audit. Every finding was independently re-verified against the source and, for the security-critical ones, confirmed end-to-end against the built binary.

## Security-verdict correctness
- **alg:none bypass** — `jwt::verify_with_options` returned `Ok(true)` for a `none` token *regardless of the supplied key*. Callers that pass a real key (`crack`, `jwks verify`, REST/MCP crack endpoints) therefore treated unsigned tokens as validly signed — crack "found" bogus secrets and `jwks verify` reported unsigned tokens as VALID. Now `none` is only accepted when **no key material** is supplied (inspection); with a key it returns `false`.
- **verify accepts malformed 4-segment tokens** — a JWS must be exactly 3 segments; extra segments were silently ignored and the token reported as validly signed. Now rejected.
- **JWE scan skipped header-injection checks** — `kid`/`jku`/`x5u`/`jwk`/`crit` are now checked for JWEs, not just JWSs.
- **scan** — flags a present-but-non-numeric `exp`, empty JWE IV/tag, and no longer misclassifies JWE key-management algs (`RSA-OAEP`/`RSA1_5`) as RS→HS confusion.

## Crashes / resource exhaustion
- **shell tab-completion panic** on multi-byte whitespace (char-boundary slice → process abort under `panic = "abort"`); cursor clamp guarded against u16 underflow on tiny terminals.
- **crack panic** targeting a payload field on a token whose payload isn't a JSON object → now a clean error.
- **jwks** — fetched JWKS response body capped at 5 MiB (was unbounded).
- **shell** — output buffer bounded; TUI rendering pauses while a background crack/scan redirects global stdout (was corrupting/freezing the TUI).

## Silent wrong behavior
- **wordlist reading** (scan/crack/server) no longer stops at the first non-UTF-8 line; scan warns on an unreadable wordlist instead of silently using the built-in list; `--max-crack-attempts` honored without `-w`.
- **ES512 + `--compress`** now errors instead of silently dropping compression.
- **shell history** no longer persists `set secret` / `set private_key` in plaintext.
- **targeted-field crack** warns that it can only match empty-secret/`none` tokens (it re-signs candidates with an empty secret).

## Testing
- 10 new regression tests added.
- `cargo build --release`, `cargo clippy --all-targets`, and the full test suite (564 tests) all pass clean.

## Note
Targeted-field cracking's core design (comparing signatures re-signed with an empty secret) can only ever match empty-secret/`none` tokens; making it work against real tokens needs a known-key input (a feature change), so this PR adds a warning rather than redesigning it.