### PR TITLE
docs: fix inaccurate command and configuration documentation

### DIFF
--- a/docs/content/advanced/scripting-automation.md
+++ b/docs/content/advanced/scripting-automation.md
@@ -4,16 +4,31 @@ title = "Scripting & Automation"
 weight = 2
 +++
 
-JWT-HACK is designed to work well in scripts and automated workflows.
+JWT-HACK is designed to work well in scripts and automated workflows. Use the
+global `--json` flag to get machine-readable output for any command.
 
-## Exit Codes
+## Exit Codes and Result Detection
 
-JWT-HACK uses standard exit codes for automation:
+> **Important:** JWT-HACK does **not** signal outcomes like "signature invalid" or
+> "secret not found" through exit codes. Commands such as `decode`, `verify`, and
+> `crack` still exit `0` in those cases — the result is reported in the output, not
+> the status code. Do **not** branch on `jwt-hack verify ...` succeeding/failing.
 
-- **0** - Success
-- **1** - General error
-- **2** - Invalid input/arguments
-- **3** - Authentication/verification failure
+Observed exit codes:
+
+- **0** - The command ran (this includes "token invalid" and "secret not found")
+- **1** - A hard error while producing `--json` output, or a config/runtime failure
+- **2** - Invalid command-line arguments (from argument parsing)
+
+To detect results reliably, use `--json` and inspect the response fields:
+
+```bash
+# verify → parse the "valid" boolean
+jwt-hack --json verify "$TOKEN" --secret="$SECRET" | jq -e '.valid == true'
+
+# crack → "found" is true and "value" holds the secret
+jwt-hack --json crack -w wordlist.txt "$TOKEN" | jq -e '.found == true'
+```
 
 ## Bash Scripting
 
@@ -26,7 +41,8 @@ validate_token() {
     local token="$1"
     local secret="$2"
 
-    if jwt-hack verify "$token" --secret="$secret" > /dev/null 2>&1; then
+    # verify exits 0 even for an invalid signature, so check the JSON "valid" field.
+    if [ "$(jwt-hack --json verify "$token" --secret="$secret" | jq -r '.valid')" = "true" ]; then
         echo "Token is valid"
         return 0
     else
@@ -74,9 +90,12 @@ crack_token() {
 
     echo "Attempting to crack token..."
 
-    if result=$(jwt-hack crack -w "$wordlist" "$token" 2>&1); then
-        echo "SUCCESS: Secret found!"
-        echo "$result" | grep "Secret:"
+    # crack exits 0 whether or not a secret is found, so check the JSON output.
+    local json secret
+    json=$(jwt-hack --json crack -w "$wordlist" "$token")
+    if [ "$(echo "$json" | jq -r '.found')" = "true" ]; then
+        secret=$(echo "$json" | jq -r '.value')
+        echo "SUCCESS: Secret found: $secret"
         return 0
     else
         echo "FAILED: Could not crack token"
@@ -107,29 +126,22 @@ import json
 import sys
 
 def decode_jwt(token):
-    """Decode JWT token using jwt-hack"""
-    try:
-        result = subprocess.run(
-            ['jwt-hack', 'decode', token],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        return result.stdout
-    except subprocess.CalledProcessError:
-        return None
+    """Decode a JWT and return the parsed JSON result, or None on error."""
+    result = subprocess.run(
+        ['jwt-hack', '--json', 'decode', token],
+        capture_output=True, text=True
+    )
+    data = json.loads(result.stdout or '{}')
+    return data if data.get('success') else None
 
 def verify_jwt(token, secret):
-    """Verify JWT token"""
-    try:
-        subprocess.run(
-            ['jwt-hack', 'verify', token, '--secret', secret],
-            capture_output=True,
-            check=True
-        )
-        return True
-    except subprocess.CalledProcessError:
-        return False
+    """Verify a JWT signature. Returns True only if the JSON `valid` field is true."""
+    result = subprocess.run(
+        ['jwt-hack', '--json', 'verify', token, '--secret', secret],
+        capture_output=True, text=True
+    )
+    data = json.loads(result.stdout or '{}')
+    return bool(data.get('valid'))
 
 # Usage
 token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
@@ -140,6 +152,10 @@ else:
     print("Failed to decode token")
     sys.exit(1)
 ```
+
+> Note: jwt-hack does not use exit codes to report an invalid signature or a
+> failed crack — always pass `--json` and inspect the response fields
+> (`valid`, `found`, `value`, …) rather than relying on `check=True`.
 
 ### Token Analysis Pipeline
 
@@ -155,65 +171,32 @@ class JWTAnalyzer:
     def __init__(self):
         self.jwt_hack = "jwt-hack"
 
+    def _run_json(self, *args):
+        """Run a jwt-hack subcommand with --json and return the parsed result."""
+        result = subprocess.run(
+            [self.jwt_hack, '--json', *args],
+            capture_output=True, text=True
+        )
+        return json.loads(result.stdout or '{}')
+
     def decode(self, token):
-        """Decode JWT and extract information"""
-        try:
-            result = subprocess.run(
-                [self.jwt_hack, 'decode', token],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            return self._parse_decode_output(result.stdout)
-        except subprocess.CalledProcessError:
-            return None
+        """Decode JWT and return the structured JSON result."""
+        data = self._run_json('decode', token)
+        return data if data.get('success') else None
 
     def verify(self, token, secret):
-        """Verify JWT signature"""
-        try:
-            subprocess.run(
-                [self.jwt_hack, 'verify', token, '--secret', secret],
-                capture_output=True,
-                check=True
-            )
-            return True
-        except subprocess.CalledProcessError:
-            return False
+        """Verify JWT signature via the JSON `valid` field."""
+        data = self._run_json('verify', token, '--secret', secret)
+        return bool(data.get('valid'))
 
     def crack(self, token, wordlist):
-        """Attempt to crack JWT secret"""
-        try:
-            result = subprocess.run(
-                [self.jwt_hack, 'crack', '-w', wordlist, token],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            # Extract secret from output
-            if match := re.search(r'Secret: (.+)', result.stdout):
-                return match.group(1)
-        except subprocess.CalledProcessError:
-            pass
-        return None
+        """Attempt to crack the JWT secret; returns the secret or None."""
+        data = self._run_json('crack', '-w', wordlist, token)
+        return data.get('value') if data.get('found') else None
 
     def generate_payloads(self, token, target='all'):
-        """Generate attack payloads"""
-        try:
-            result = subprocess.run(
-                [self.jwt_hack, 'payload', token, '--target', target],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            return result.stdout
-        except subprocess.CalledProcessError:
-            return None
-
-    def _parse_decode_output(self, output):
-        """Parse decode output to extract structured data"""
-        # This would parse the actual output format
-        # Implementation depends on jwt-hack output format
-        return {"raw_output": output}
+        """Generate attack payloads (returns the JSON payload list)."""
+        return self._run_json('payload', token, '--target', target)
 
 # Usage example
 analyzer = JWTAnalyzer()
@@ -286,17 +269,20 @@ ENTRYPOINT ["/scripts/analyze.sh"]
 
 ### Environment-Based Configuration
 
+jwt-hack itself does not read these values from the environment, so read them into
+shell variables and pass them explicitly as flags:
+
 ```bash
 #!/bin/bash
 
-# Set defaults from environment
-JWT_HACK_SECRET="${JWT_HACK_SECRET:-default-secret}"
-JWT_HACK_WORDLIST="${JWT_HACK_WORDLIST:-/usr/share/wordlists/rockyou.txt}"
-JWT_HACK_CONCURRENCY="${JWT_HACK_CONCURRENCY:-$(nproc)}"
+# Set defaults from environment (your own variables, not read by jwt-hack)
+SECRET="${SECRET:-default-secret}"
+WORDLIST="${WORDLIST:-/usr/share/wordlists/rockyou.txt}"
+CONCURRENCY="${CONCURRENCY:-$(nproc)}"
 
-# Use in scripts
-jwt-hack verify "$token" --secret="$JWT_HACK_SECRET"
-jwt-hack crack -w "$JWT_HACK_WORDLIST" -c "$JWT_HACK_CONCURRENCY" "$token"
+# Pass them explicitly on the command line
+jwt-hack verify "$token" --secret="$SECRET"
+jwt-hack crack -w "$WORDLIST" -c "$CONCURRENCY" "$token"
 ```
 
 ### Config File Generation

--- a/docs/content/get_started/installation.md
+++ b/docs/content/get_started/installation.md
@@ -62,4 +62,5 @@ Once installed, verify that JWT-HACK is working correctly:
 jwt-hack --version
 ```
 
-You should see the version information and the JWT-HACK banner displayed.
+You should see the version information printed. (Running `jwt-hack` with no
+arguments, or `jwt-hack help`, displays the JWT-HACK banner and usage.)

--- a/docs/content/get_started/introduction.md
+++ b/docs/content/get_started/introduction.md
@@ -24,12 +24,13 @@ JWT-HACK provides comprehensive JWT security testing capabilities with support f
 - **HS384** - HMAC using SHA-384
 - **HS512** - HMAC using SHA-512
 
-### Asymmetric Algorithms (RSA/ECDSA)
-- **RS256** - RSASSA-PKCS1-v1_5 using SHA-256
-- **RS384** - RSASSA-PKCS1-v1_5 using SHA-384
-- **RS512** - RSASSA-PKCS1-v1_5 using SHA-512
+### Asymmetric Algorithms (RSA/ECDSA/EdDSA)
+- **RS256/RS384/RS512** - RSASSA-PKCS1-v1_5 using SHA-256/384/512
+- **PS256/PS384/PS512** - RSASSA-PSS using SHA-256/384/512
 - **ES256** - ECDSA using P-256 and SHA-256
 - **ES384** - ECDSA using P-384 and SHA-384
+- **ES512** - ECDSA using P-521 and SHA-512
+- **EdDSA** - Edwards-curve Digital Signature Algorithm (Ed25519)
 
 ### Special Cases
 - **None** - Unsigned tokens for testing

--- a/docs/content/reference/environment-variables.md
+++ b/docs/content/reference/environment-variables.md
@@ -4,19 +4,41 @@ title = "Environment Variables"
 weight = 1
 +++
 
-Environment variables for configuring JWT-HACK behavior.
+Environment variables that affect JWT-HACK behavior.
 
 ## Available Environment Variables
 
-This section is currently under development. Environment variables will be documented here once the feature is implemented.
+### `XDG_CONFIG_HOME`
 
-## Planned Variables
+Overrides the base directory used to locate the configuration file. When set,
+JWT-HACK looks for its config at `$XDG_CONFIG_HOME/jwt-hack/config.toml`. When
+unset, it falls back to the platform default config directory (see
+[Configuration](/usage/configuration)).
 
-The following environment variables are planned for future releases:
+```bash
+export XDG_CONFIG_HOME="$HOME/.config"
+# jwt-hack now reads ~/.config/jwt-hack/config.toml
+```
 
-- `JWT_HACK_SECRET` - Default secret for HMAC operations
-- `JWT_HACK_ALGORITHM` - Default algorithm selection
-- `JWT_HACK_CONFIG` - Custom configuration file path
-- `JWT_HACK_DEBUG` - Enable debug output
+### `JWT_HACK_WORDLIST_DIR`
 
-Check back for updates or refer to the [Configuration](/usage/configuration) documentation for current configuration options.
+Used only by the [`server`](/usage/commands/server) command. Server-side wordlist
+**file paths** (the `wordlist` field in `/crack` and `/scan` requests) are
+disabled by default; clients are expected to send inline wordlists via
+`wordlist_content`. Setting `JWT_HACK_WORDLIST_DIR` to a directory re-enables
+path-based wordlists, but only for files that resolve inside that directory —
+paths outside it are rejected.
+
+```bash
+export JWT_HACK_WORDLIST_DIR=/opt/wordlists
+jwt-hack server
+# /crack and /scan may now reference wordlist files under /opt/wordlists
+```
+
+## Notes
+
+- There are no environment variables for setting the default secret, algorithm,
+  wordlist, or private key. Those are configured through the
+  [configuration file](/usage/configuration) or per-command flags.
+- The path to the configuration file itself is set with the global `--config`
+  flag, not an environment variable.

--- a/docs/content/usage/commands/crack.md
+++ b/docs/content/usage/commands/crack.md
@@ -85,10 +85,27 @@ jwt-hack crack -m brute <TOKEN> --max=5
 ```
 
 **Character Sets:**
-- Lowercase letters (a-z)
-- Uppercase letters (A-Z)
-- Numbers (0-9)
-- Special characters (!@#$%^&*)
+
+By default, brute force uses lowercase letters and digits
+(`abcdefghijklmnopqrstuvwxyz0123456789`). You can override the character set with
+`--chars`, or pick a built-in `--preset`:
+
+| Preset  | Characters                                    |
+|---------|-----------------------------------------------|
+| `az`    | Lowercase letters (a-z)                       |
+| `AZ`    | Uppercase letters (A-Z)                       |
+| `aZ`    | Mixed-case letters (a-z, A-Z)                 |
+| `19`    | Digits (0-9)                                  |
+| `aZ19`  | Letters and digits (a-z, A-Z, 0-9)            |
+| `ascii` | All printable ASCII (letters, digits, symbols) |
+
+```bash
+# Custom character set
+jwt-hack crack -m brute <TOKEN> --chars="abcdef0123456789"
+
+# Character-set preset
+jwt-hack crack -m brute <TOKEN> --preset=aZ19
+```
 
 ## Performance Options
 
@@ -102,16 +119,18 @@ jwt-hack crack -w wordlist.txt <TOKEN> --power
 ```
 
 ### Progress Monitoring
+A live progress bar is shown during cracking by default. The `--verbose` flag
+additionally logs each candidate as it is tested:
+
 ```bash
-# Enable verbose output
+# Enable verbose testing log
 jwt-hack crack -w wordlist.txt <TOKEN> --verbose
 
-# Shows:
-# - Current password being tested
-# - Progress percentage
-# - Estimated time remaining
-# - Passwords tested per second
+# Logs each tested candidate, plus a "Found!" line when the secret is discovered.
 ```
+
+When the run finishes, jwt-hack prints the discovered secret (if any), the elapsed
+time, and the throughput in keys/sec.
 
 ## Command Options
 
@@ -119,15 +138,24 @@ jwt-hack crack -w wordlist.txt <TOKEN> --verbose
 - `<TOKEN>` - The JWT token to crack
 
 ### Attack Mode Options
-- `-w, --wordlist <FILE>` - Path to wordlist file
+- `-w, --wordlist <FILE>` - Path to wordlist file (dictionary mode)
 - `-p, --wordlist-preset <ID>` - Download & use a preset wordlist (1=raft-medium-words, 2=raft-large-words, 3=jwt-secrets)
-- `-m, --mode <MODE>` - Attack mode: dictionary (default) or brute
+- `-m, --mode <MODE>` - Attack mode: `dict` (default) or `brute`
+
+### Brute Force Options
+- `--chars <CHARS>` - Character set to use (default: `abcdefghijklmnopqrstuvwxyz0123456789`)
+- `--preset <PRESET>` - Character-set preset: `az`, `AZ`, `aZ`, `19`, `aZ19`, `ascii`
+- `--min <LENGTH>` - Minimum candidate length (default: 1)
+- `--max <LENGTH>` - Maximum candidate length (default: 4)
+
+### Targeted Field Options
+- `--target-field <FIELD>` - Target a specific JWT field for brute force (e.g. `kid`, `jti`)
+- `--pattern <TEMPLATE>` - Pattern template for targeted values, using `{}` as the placeholder (e.g. `"../../keys/{}"`)
 
 ### Performance Options
 - `-c, --concurrency <NUM>` - Number of threads (default: 20)
-- `--max <LENGTH>` - Maximum length for brute force (default: 4)
 - `--power` - Use all available CPU cores
-- `--verbose` - Show detailed progress information
+- `--verbose` - Log each tested candidate
 
 ## Compressed Token Support
 
@@ -199,14 +227,19 @@ cat wordlist1.txt wordlist2.txt > combined.txt
 
 ## Success Output
 
-When a secret is found:
+When a secret is found, jwt-hack prints the secret, the elapsed time and
+throughput, and the token:
 
 ```
-🎉 SECRET FOUND!
-Secret: mysecret123
-Time taken: 2.5 seconds
-Passwords tested: 1,247
+✔ Secret found
+
+  Secret  mysecret123
+  Time    2s (498.80 keys/sec)
+  Token   eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
+
+If no secret is found, it reports the number of candidates tried, the elapsed
+time, and the throughput.
 
 ## Performance Tips
 

--- a/docs/content/usage/commands/encode.md
+++ b/docs/content/usage/commands/encode.md
@@ -55,10 +55,11 @@ jwt-hack encode '{"sub":"1234", "name":"John Doe"}' --no-signature
 
 ## Custom Headers
 
-Add custom header fields to the JWT:
+Add custom header fields to the JWT. Each parameter is passed as a separate
+`--header key=value` flag (not a JSON object), and the flag can be repeated:
 
 ```bash
-jwt-hack encode '{"sub":"1234"}' --secret=test --header='{"kid":"key1","typ":"JWT"}'
+jwt-hack encode '{"sub":"1234"}' --secret=test --header kid=key1 --header typ=JWT
 ```
 
 ## DEFLATE Compression
@@ -99,12 +100,12 @@ JWE encoding:
 - `--private-key <PATH>` - Path to private key file for RSA/ECDSA
 
 ### Algorithm Options
-- `--algorithm <ALG>` - Algorithm to use (HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384)
-- `--no-signature` - Create unsigned token
+- `--algorithm <ALG>` - Algorithm to use (HS256/384/512, RS256/384/512, ES256/384/512, PS256/384/512, EdDSA). Defaults to the config `default_algorithm`, then HS256.
+- `--no-signature` - Create an unsigned (`alg: none`) token
 
 ### Additional Options
-- `--header <JSON>` - Custom header fields as JSON
-- `--compress` - Enable DEFLATE compression
+- `--header <KEY=VALUE>` - Add a custom header parameter (repeatable, e.g. `--header kid=key1 --header typ=JWT`)
+- `--compress` - Enable DEFLATE compression (adds `"zip":"DEF"` to the header)
 - `--jwe` - Create JWE encrypted token
 
 ## Examples
@@ -121,7 +122,7 @@ jwt-hack encode '{"iss":"myapp","aud":"users","exp":1640995200}' --private-key=r
 
 ### JWT with Custom Headers
 ```bash
-jwt-hack encode '{"user":"john"}' --secret=test --header='{"kid":"key-1","alg":"HS256","typ":"JWT"}'
+jwt-hack encode '{"user":"john"}' --secret=test --header kid=key-1 --header typ=JWT
 ```
 
 ### Compressed JWT

--- a/docs/content/usage/commands/mcp.md
+++ b/docs/content/usage/commands/mcp.md
@@ -19,47 +19,42 @@ Model Context Protocol (MCP) is a standardized protocol that enables AI models t
 ## Starting the MCP Server
 
 ```bash
-# Start MCP server on default port
+# Start the MCP server (communicates over stdio)
 jwt-hack mcp
 
 # The server will:
-# - Listen for MCP connections
+# - Speak the MCP protocol over stdin/stdout (stdio transport)
 # - Expose JWT-HACK functionality as MCP tools
-# - Process requests from AI models
+# - Process requests from an MCP-capable client
 # - Return structured responses
 ```
 
+The server uses the **stdio transport** — it reads requests from stdin and writes
+responses to stdout. It is not a network server, so there is no port to configure;
+an MCP client launches `jwt-hack mcp` as a subprocess and communicates over the pipe.
+
 ## Available MCP Tools
 
-When running as an MCP server, JWT-HACK exposes these tools to AI models:
+When running as an MCP server, JWT-HACK exposes these five tools:
 
-### JWT Analysis Tools
-- **decode-jwt** - Decode and analyze JWT tokens
-- **verify-jwt** - Verify JWT signatures
-- **crack-jwt** - Attempt to crack JWT secrets
-- **generate-payloads** - Create attack payloads
-
-### Security Testing Tools
-- **analyze-vulnerabilities** - Identify potential security issues
-- **generate-reports** - Create security assessment reports
-- **test-algorithms** - Test algorithm-specific vulnerabilities
+- **decode** - Decode a JWT token and display its header, payload, and validation info
+- **encode** - Encode JSON data into a JWT token with a specified algorithm
+- **verify** - Verify a JWT token's signature and optionally validate expiration
+- **crack** - Attempt to crack a JWT token using dictionary or bruteforce methods
+- **payload** - Generate various JWT attack payloads for security testing
 
 ## Integration Examples
 
-### With OpenAI Models
-AI models can request JWT analysis through the MCP protocol:
+An MCP-capable client (such as a Claude or other agentic tool that supports MCP)
+can call these tools during a conversation:
 
 ```
-AI Model Request: "Analyze this JWT token for security vulnerabilities"
-MCP Server: Executes decode, verify, and payload generation
-AI Model: Receives structured analysis results
+User: "Analyze this JWT token for security vulnerabilities"
+Client: Calls the `decode`, `verify`, and `payload` tools on the JWT-HACK MCP server
+Client: Receives structured results and summarizes them
 ```
 
-### With Local AI Models
-Compatible with local AI frameworks that support MCP:
-- **Ollama** with MCP plugins
-- **LangChain** MCP integration
-- **Custom AI applications** using MCP protocol
+Any client or framework that speaks MCP over stdio can connect to the server.
 
 ## MCP Protocol Features
 
@@ -68,7 +63,7 @@ Compatible with local AI frameworks that support MCP:
 {
   "method": "tools/call",
   "params": {
-    "name": "decode-jwt",
+    "name": "decode",
     "arguments": {
       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
     }
@@ -77,39 +72,13 @@ Compatible with local AI frameworks that support MCP:
 ```
 
 ### Structured Responses
-```json
-{
-  "result": {
-    "algorithm": "HS256",
-    "header": {"alg": "HS256", "typ": "JWT"},
-    "payload": {"sub": "1234", "name": "John Doe"},
-    "vulnerabilities": ["weak_secret_suspected"],
-    "recommendations": ["Use stronger secrets", "Enable expiration"]
-  }
-}
-```
+The server returns the tool result as structured MCP content, for example the
+decoded header, payload, and algorithm for the `decode` tool.
 
 ## Configuration
 
-### Server Configuration
-The MCP server can be configured through environment variables:
-
-```bash
-# Set custom port
-export MCP_PORT=8080
-jwt-hack mcp
-
-# Enable debug logging
-export MCP_DEBUG=true
-jwt-hack mcp
-
-# Set custom timeout
-export MCP_TIMEOUT=30
-jwt-hack mcp
-```
-
-### AI Model Configuration
-Configure your AI model to connect to the JWT-HACK MCP server:
+### Client Configuration
+Configure your MCP client to launch the JWT-HACK MCP server as a subprocess:
 
 ```json
 {
@@ -167,9 +136,9 @@ Integrate into automated testing workflows:
 
 ### Protocol Compliance
 JWT-HACK's MCP server implements:
-- **MCP 1.0 specification** compliance
+- The **Model Context Protocol** (built on the `rmcp` crate)
 - **JSON-RPC 2.0** message format
-- **WebSocket** transport layer
+- **stdio** transport layer (stdin/stdout)
 - **Tool discovery** and capability advertisement
 
 ### Performance Characteristics
@@ -180,52 +149,22 @@ JWT-HACK's MCP server implements:
 
 ## Troubleshooting
 
-### Connection Issues
-```bash
-# Check if MCP server is running
-netstat -ln | grep :8080
+Because the server uses the stdio transport, it is normally launched and managed
+by the MCP client rather than run by hand. If you run `jwt-hack mcp` directly in a
+terminal, it will wait for MCP messages on stdin and appear to "hang" — this is
+expected. Common checks:
 
-# Test MCP connection manually
-curl -X POST http://localhost:8080/mcp
-
-# Enable debug logging
-MCP_DEBUG=true jwt-hack mcp
-```
-
-### AI Model Integration
-```bash
-# Verify AI model can discover tools
-# Check MCP protocol compatibility
-# Validate request/response formats
-```
-
-## Development and Extensions
-
-### Custom MCP Tools
-The MCP server architecture allows for extending JWT-HACK with custom tools:
-
-```rust
-// Example: Add custom JWT analysis tool
-impl McpTool for CustomJwtAnalyzer {
-    fn name(&self) -> &str { "custom-analysis" }
-    fn execute(&self, args: Value) -> Result<Value> {
-        // Custom JWT analysis logic
-    }
-}
-```
-
-### Protocol Extensions
-- Custom error handling
-- Extended metadata support
-- Streaming responses for long operations
-- Batch processing capabilities
+- Confirm the client is configured to launch `jwt-hack mcp` as a subprocess (see
+  the client configuration above).
+- Ensure `jwt-hack` is on the `PATH` the client uses.
+- Verify the tool is discoverable by having the client list available tools; it
+  should report `decode`, `encode`, `verify`, `crack`, and `payload`.
 
 ## Security Considerations
 
 ### Access Control
-- MCP server runs locally by default
-- Consider network security for remote access
-- Implement authentication for production use
+- The MCP server runs locally as a subprocess of the client (stdio transport)
+- It does not open a network port, so it is only reachable by the launching client
 
 ### Data Privacy
 - JWT tokens are processed locally

--- a/docs/content/usage/commands/scan.md
+++ b/docs/content/usage/commands/scan.md
@@ -31,10 +31,10 @@ The current scanner performs the following checks:
   - `kid` presence (possible SQL/path injection surfaces).
   - `jku` / `x5u` presence (possible URL spoofing / remote JWKS risks).
 - Attack payload suggestions (optional)
-  - Prints example payloads for detected issues: `none`, `alg_confusion`, `kid_sql`.
+  - Prints example payloads matched to the issues actually detected. Depending on findings this can include `none`, `alg_confusion`, `kid_sql`/`kid_traversal`, `jku`/`x5u`, `jwk_embed`, `crit`, `b64`, `empty_sig`, `typ_confusion`, `alg_edge`, `psychic`, and `zip`.
 
 Notes:
-- JWE (5-part) tokens are not supported by `scan`.
+- JWE (5-part) tokens are supported: a JWE is routed to a dedicated encryption-layer analysis (key-management `alg`, content `enc`, CBC/padding-oracle and compression risks) instead of the JWS signature checks above.
 - Compressed JWT payloads (`zip: "DEF"`) are decoded but not separately highlighted as a finding.
 
 ## Options
@@ -122,7 +122,7 @@ Total Vulnerabilities Found: 3
 ⚠️  Review the vulnerabilities above and consider generating attack payloads.
 
 ━━━ Generating Attack Payloads ━━━
-... (example payloads for 'none', 'alg_confusion', 'kid_sql')
+... (example payloads matched to the detected findings)
 ```
 
 If the scan finds no significant issues, you'll see:
@@ -136,8 +136,8 @@ If the scan finds no significant issues, you'll see:
   - Secret cracking runs only when the algorithm is HMAC (HS256/384/512). For non‑HS* tokens, this check is skipped as "Not applicable".
 - Algorithm confusion is heuristic
   - Asymmetric algorithms are flagged as "needs testing" (High) to prompt follow‑up validation; it is not a confirmed vulnerability by itself.
-- JKU/X5U payloads
-  - The scanner flags the presence of these headers, but the current payload generation prints examples for `none`, `alg_confusion`, and `kid_sql`. It does not print `jku/x5u` payload examples in this command's output.
+- Payload examples follow the findings
+  - The payload section only emits examples for issues the scan actually detected. A flagged `jku`/`x5u` header, for instance, does contribute `jku`/`x5u` payload examples; a token with no such finding will not.
 
 ## Recommended Workflow
 
@@ -160,8 +160,8 @@ If the scan finds no significant issues, you'll see:
 
 ## Troubleshooting
 
-- JWE input: `scan` expects a JWT (3 parts). 5‑part JWE tokens are not supported.
-- If the scan terminates early, ensure the token uses the standard `<header>.<payload>.<signature>` format.
+- Token format: `scan` accepts both a 3-part JWT (`<header>.<payload>.<signature>`) and a 5-part JWE; other segment counts are reported as an unexpected token shape.
+- If the scan terminates early, ensure the token is a well-formed JWT or JWE.
 - For faster results, use `--skip-crack` or set `--max-crack-attempts` to a small number.
 - Wordlist path errors: provide an absolute path or a path relative to your project root.
 - Usage hint (shown on errors):

--- a/docs/content/usage/commands/server.md
+++ b/docs/content/usage/commands/server.md
@@ -157,22 +157,27 @@ Notes:
 
 ### Crack
 - Request:
-```/dev/null/crack-request.json#L1-18
+```/dev/null/crack-request.json#L1-20
 {
   "token": "eyJhbGciOi...",
   // "dict" (default) or "brute"
   "mode": "dict",
 
-  // Required when mode="dict": file path accessible to the server process
-  // (e.g., "samples/wordlist.txt")
-  "wordlist": "samples/wordlist.txt",
+  // For mode="dict": provide an inline wordlist (preferred). One secret per entry.
+  "wordlist_content": ["secret", "password", "hunter2"],
+
+  // Alternatively a server-side file path. Path-based wordlists are DISABLED by
+  // default and only honored when the path resolves inside the directory named by
+  // the JWT_HACK_WORDLIST_DIR environment variable (otherwise the request is rejected).
+  "wordlist": "wordlist.txt",
 
   // Used when mode="brute":
-  // Either specify "preset" or provide a custom "chars" and "max".
+  // Either specify "preset" or provide a custom "chars", "min", and "max".
   // Presets: "az", "AZ", "aZ", "19", "aZ19", "ascii"
   "preset": "aZ19",
   "chars": "abcdefghijklmnopqrstuvwxyz0123456789",
   "concurrency": 20,  // accepted but not leveraged by the current API code
+  "min": 1,
   "max": 4
 }
 ```
@@ -189,8 +194,8 @@ Notes:
 ```
 
 Notes:
-- Dictionary mode requires a file path on the server host. The API does not upload wordlists.
-- Brute-force tries all combinations up to `max` using `chars` or a `preset`.
+- Dictionary mode reads secrets from the inline `wordlist_content` array (preferred, so clients never depend on server-side files). Server-side `wordlist` file paths are disabled unless `JWT_HACK_WORDLIST_DIR` is set and the path resolves inside it.
+- Brute-force tries all combinations from `min` to `max` length using `chars` or a `preset`.
 - This endpoint executes synchronously and can be CPU-intensive; prefer small search spaces or offload heavy jobs to batch workers.
 
 ### Payload
@@ -232,15 +237,17 @@ Notes:
 
 ### Scan
 - Request:
-```/dev/null/scan-request.json#L1-12
+```/dev/null/scan-request.json#L1-14
 {
   "token": "eyJhbGciOi...",
   // If true, skip dictionary-based weak secret check
   "skip_crack": false,
   // Accepted but not used by current server-side implementation
   "skip_payloads": false,
-  // Optional path for wordlist (used if skip_crack=false)
-  "wordlist": "samples/wordlist.txt",
+  // Optional inline wordlist for the weak-secret check (preferred)
+  "wordlist_content": ["secret", "password"],
+  // Optional server-side wordlist path; same JWT_HACK_WORDLIST_DIR gating as /crack
+  "wordlist": "wordlist.txt",
   // Accepted but not enforced by current implementation
   "max_crack_attempts": 100
 }
@@ -265,7 +272,7 @@ Notes:
 - The scan performs:
   - Basic header check for `alg:"none"`.
   - Expiration check on `exp` if present.
-  - Optional weak secret discovery via dictionary if `wordlist` is provided and `skip_crack` is false.
+  - Optional weak secret discovery via dictionary if a wordlist (`wordlist_content` inline, or a `JWT_HACK_WORDLIST_DIR`-gated `wordlist` path) is provided and `skip_crack` is false.
 - It does not currently generate payloads despite accepting `skip_payloads` (reserved for future behavior).
 
 ---
@@ -322,7 +329,8 @@ curl -s http://127.0.0.1:3000/verify \
 curl -s http://127.0.0.1:3000/crack \
   -H 'Content-Type: application/json' \
   -d '{
-        "token":"<your-token>", "mode":"dict", "wordlist":"samples/wordlist.txt"
+        "token":"<your-token>", "mode":"dict",
+        "wordlist_content":["secret","password","hunter2"]
       }'
 ```
 
@@ -353,7 +361,7 @@ curl -s http://127.0.0.1:3000/scan \
   -H 'Content-Type: application/json' \
   -d '{
         "token":"<your-token>",
-        "skip_crack":false, "wordlist":"samples/wordlist.txt"
+        "skip_crack":false, "wordlist_content":["secret","password"]
       }'
 ```
 

--- a/docs/content/usage/commands/verify.md
+++ b/docs/content/usage/commands/verify.md
@@ -66,29 +66,29 @@ With `--validate-exp`, the command will:
 
 ## Verification Results
 
-The verify command provides detailed output:
+The verify command reports whether the signature is valid:
 
 ### Successful Verification
 ```
-✓ Signature Valid
-✓ Token Structure Valid
-✓ Algorithm: HS256
-✓ Expiration: Valid (expires in 2 hours)
+Token is valid.
 ```
 
 ### Failed Verification
+On failure, the command prints the error and a hint about the likely cause, e.g.:
 ```
-✗ Signature Invalid
-✓ Token Structure Valid
-- Algorithm: HS256
-- Reason: Incorrect secret or signature tampering
+Token is invalid.
+```
+or, when verification errors out:
+```
+JWT Verification Error: Invalid signature
+This could be due to an incorrect secret or key.
 ```
 
 ### Expiration Issues
+With `--validate-exp`, an expired token surfaces an expiration error:
 ```
-✓ Signature Valid
-✓ Token Structure Valid
-✗ Expiration: Token expired 30 minutes ago
+JWT Verification Error: Expired signature
+The token has expired. Check the 'exp' claim.
 ```
 
 ## Examples
@@ -156,18 +156,19 @@ jwt-hack verify <RSA_TOKEN> --secret=<PUBLIC_KEY_CONTENT>
 jwt-hack verify <NONE_TOKEN>
 ```
 
-## Return Codes
+## Scripting
 
-The verify command uses exit codes for scripting:
+The verify command does **not** currently signal validity through distinct exit
+codes — an invalid signature is reported in the output but still exits `0`. For
+reliable scripting, use the global `--json` flag and parse the `valid` field:
 
-- **0** - Verification successful
-- **1** - Verification failed
-- **2** - Token format error
-- **3** - Expiration validation failed
-
-Example usage in scripts:
 ```bash
-if jwt-hack verify "$TOKEN" --secret="$SECRET"; then
+jwt-hack --json verify "$TOKEN" --secret="$SECRET"
+# => {"success":true,"valid":true,"validate_exp":false}
+```
+
+```bash
+if [ "$(jwt-hack --json verify "$TOKEN" --secret="$SECRET" | jq -r .valid)" = "true" ]; then
     echo "Token is valid"
 else
     echo "Token verification failed"

--- a/docs/content/usage/configuration.md
+++ b/docs/content/usage/configuration.md
@@ -4,14 +4,17 @@ title = "Configuration"
 weight = 3
 +++
 
-JWT-HACK supports configuration through configuration files, environment variables, and command-line options.
+JWT-HACK supports configuration through a configuration file and command-line options. Command-line flags always take precedence over values from the config file.
 
 ## Configuration File
 
-JWT-HACK uses TOML format for configuration files. The default configuration file location follows XDG Base Directory specification:
+JWT-HACK uses TOML format for configuration files. The default configuration file location is the platform config directory:
 
-- **Linux/macOS**: `~/.config/jwt-hack/config.toml`
+- **Linux**: `~/.config/jwt-hack/config.toml` (or `$XDG_CONFIG_HOME/jwt-hack/config.toml`)
+- **macOS**: `~/Library/Application Support/jwt-hack/config.toml`
 - **Windows**: `%APPDATA%\jwt-hack\config.toml`
+
+Setting `XDG_CONFIG_HOME` overrides the base directory on any platform.
 
 ### Configuration File Format
 
@@ -64,8 +67,10 @@ default_algorithm = "HS512"
 
 Supported algorithms:
 - `HS256`, `HS384`, `HS512` (HMAC)
-- `RS256`, `RS384`, `RS512` (RSA)
-- `ES256`, `ES384` (ECDSA)
+- `RS256`, `RS384`, `RS512` (RSA PKCS#1 v1.5)
+- `PS256`, `PS384`, `PS512` (RSA-PSS)
+- `ES256`, `ES384`, `ES512` (ECDSA)
+- `EdDSA` (Ed25519)
 
 ### Default Wordlist
 Set default wordlist for cracking operations:
@@ -92,45 +97,32 @@ default_private_key = "/path/to/default/key.pem"
 
 ## Environment Variables
 
-Override configuration with environment variables:
+JWT-HACK does not read the default secret, algorithm, wordlist, or private key
+from environment variables. Those values come only from the configuration file
+(or the corresponding command-line flag).
 
-```bash
-# Default secret
-export JWT_HACK_DEFAULT_SECRET="env-secret"
+A small number of environment variables affect other behavior — `XDG_CONFIG_HOME`
+(config file location) and `JWT_HACK_WORDLIST_DIR` (server-mode wordlist paths).
+See [Environment Variables](/reference/environment-variables) for details.
 
-# Default algorithm
-export JWT_HACK_DEFAULT_ALGORITHM="RS256"
+## Setting Priority
 
-# Default wordlist
-export JWT_HACK_DEFAULT_WORDLIST="/path/to/wordlist.txt"
-
-# Default private key
-export JWT_HACK_DEFAULT_PRIVATE_KEY="/path/to/key.pem"
-
-# Configuration file path
-export JWT_HACK_CONFIG="/path/to/config.toml"
-```
-
-## Command Line Priority
-
-Configuration options follow this priority order (highest to lowest):
+Configuration values follow this priority order (highest to lowest):
 
 1. **Command line arguments** (highest priority)
-2. **Environment variables**
-3. **Configuration file**
-4. **Built-in defaults** (lowest priority)
+2. **Configuration file** (`default_*` keys)
+3. **Built-in defaults** (lowest priority)
 
 Example:
 ```bash
 # Config file has: default_secret = "config-secret"
-# Environment has: JWT_HACK_DEFAULT_SECRET="env-secret"
 # Command line: --secret=cli-secret
 
 jwt-hack encode '{"sub":"1234"}' --secret=cli-secret
 # Uses: cli-secret (command line wins)
 
 jwt-hack encode '{"sub":"1234"}'
-# Uses: env-secret (environment wins over config file)
+# Uses: config-secret (from the config file)
 ```
 
 ## Configuration Management
@@ -151,14 +143,11 @@ EOF
 ```
 
 ### Validate Configuration
-Test your configuration:
+Test that a config file loads without a parse error by running any command with it:
 
 ```bash
-# Test with specific config file
+# A TOML syntax error causes jwt-hack to exit with a "Failed to parse config file" error
 jwt-hack --config ~/.config/jwt-hack/config.toml encode '{"test":"payload"}'
-
-# Verify settings are loaded correctly
-jwt-hack version  # Shows config file location if found
 ```
 
 ### Per-Project Configuration
@@ -176,53 +165,26 @@ cd project
 jwt-hack --config ./config.toml crack <TOKEN>
 ```
 
-## Advanced Configuration
+## Available Configuration Keys
 
-### Wordlist Collections
-Organize multiple wordlists:
+The configuration file currently supports exactly these top-level keys, all optional:
 
-```toml
-[wordlists]
-common = "/wordlists/common-passwords.txt"
-large = "/wordlists/rockyou.txt"
-custom = "/wordlists/app-specific.txt"
-```
+| Key                   | Type   | Description                                        |
+|-----------------------|--------|----------------------------------------------------|
+| `default_secret`      | string | Default HMAC secret                                |
+| `default_algorithm`   | string | Default algorithm for `encode`                     |
+| `default_wordlist`    | string | Default wordlist path for `crack`/`scan`           |
+| `default_private_key` | string | Default private key path for asymmetric algorithms |
 
-### Key Management
-Configure multiple key files:
-
-```toml
-[keys]
-rsa_private = "/keys/rsa-private.pem"
-rsa_public = "/keys/rsa-public.pem"
-ecdsa_private = "/keys/ecdsa-private.pem"
-```
-
-### Performance Tuning
-Configure performance settings:
-
-```toml
-[performance]
-default_concurrency = 8
-max_memory_usage = "1GB"
-timeout = 300
-```
+Unknown keys are ignored, so there are no `[wordlists]`, `[keys]`, or
+`[performance]` sections — only the flat keys above.
 
 ## Security Considerations
 
 ### Sensitive Data in Config
-Avoid storing sensitive secrets in configuration files:
-
-```toml
-# BAD: Hardcoded secret in config
-default_secret = "super-secret-key"
-
-# BETTER: Reference to secure location
-default_secret_file = "/secure/path/secret.txt"
-
-# BEST: Use environment variables for secrets
-# default_secret loaded from JWT_HACK_DEFAULT_SECRET
-```
+A secret placed in `default_secret` is stored in plain text in the config file.
+If that is a concern, omit it from the file and pass `--secret` per command
+instead. There is no `default_secret_file` key.
 
 ### File Permissions
 Secure configuration files:
@@ -236,35 +198,30 @@ ls -la ~/.config/jwt-hack/config.toml
 # Should show: -rw------- (user read/write only)
 ```
 
-### Configuration Validation
-JWT-HACK validates configuration on startup:
-
-- Checks file paths exist
-- Validates algorithm names
-- Warns about insecure settings
-- Reports configuration errors clearly
+### Configuration Loading
+On startup, JWT-HACK parses the config file as TOML. Invalid TOML causes it to
+exit with a "Failed to parse config file" error. Values such as algorithm names
+and key/wordlist paths are not validated at load time — they are only used (and
+may error) when the relevant command runs.
 
 ## Troubleshooting
 
 ### Configuration Not Loading
+The default config file is only read if it exists at the platform config path. If
+it is not being picked up:
+
 ```bash
-# Check if config file exists
+# Confirm the file exists at the expected location (Linux example)
 ls -la ~/.config/jwt-hack/config.toml
 
-# Test with explicit config path
-jwt-hack --config ~/.config/jwt-hack/config.toml version
-
-# Enable debug output
-JWT_HACK_DEBUG=true jwt-hack encode '{"test":"1"}'
+# Or point jwt-hack at the file explicitly
+jwt-hack --config /path/to/config.toml encode '{"test":"1"}'
 ```
 
 ### Invalid Configuration
 ```bash
-# Check configuration syntax
-toml-lint ~/.config/jwt-hack/config.toml
-
-# Test configuration loading
-jwt-hack --config ~/.config/jwt-hack/config.toml version
+# A parse error names the file; check its TOML syntax
+jwt-hack --config /path/to/config.toml encode '{"test":"1"}'
 ```
 
 ### Permission Issues

--- a/docs/content/usage/examples.md
+++ b/docs/content/usage/examples.md
@@ -90,10 +90,11 @@ jwt-hack crack -w wordlist.txt <COMPRESSED_TOKEN>
 ### Custom Headers
 
 ```bash
-# Add custom header fields
+# Add custom header fields (one --header key=value per parameter)
 jwt-hack encode '{"sub":"1234"}' \
   --secret=test \
-  --header='{"kid":"key-123","x5u":"https://example.com/certs"}'
+  --header kid=key-123 \
+  --header x5u=https://example.com/certs
 ```
 
 ### Multiple Algorithms


### PR DESCRIPTION
## Summary

The `docs/` content described a fair amount of behavior that the code does not actually implement. This PR reconciles the docs with the current source (jwt-hack 2.6.0).

## Fixes

- **encode / examples** — `--header` takes repeated `key=value` flags, not a JSON object (`--header kid=key1 --header typ=JWT`).
- **verify** — Removed the fabricated exit-code table. `verify` exits `0` even when the signature is invalid, so the doc now points at the `--json` `valid` field for scripting, and the output samples match real output.
- **crack** — `--mode` value is `dict` (not `dictionary`); documented the real default charset (lowercase + digits), plus `--chars` / `--preset` / `--min` / `--target-field` / `--pattern`; corrected the `--verbose` and success-output descriptions.
- **mcp** — Corrected the tool names (`decode`, `encode`, `verify`, `crack`, `payload`), the **stdio** transport (not WebSocket / a network port), and removed the nonexistent `MCP_PORT` / `MCP_DEBUG` / `MCP_TIMEOUT` env vars and the curl/netstat troubleshooting.
- **scan** — `scan` now supports 5-part JWE tokens (dedicated encryption-layer analysis) and prints payload examples for every detected finding, including `jku`/`x5u`. The old "JWE not supported" / limited-payload notes were wrong.
- **server** — Dictionary wordlists use inline `wordlist_content`; server-side file paths are disabled unless gated by `JWT_HACK_WORDLIST_DIR`. Updated request schemas and cURL examples.
- **configuration / environment-variables** — Removed nonexistent env-var overrides and `[wordlists]` / `[keys]` / `[performance]` sections; documented the real env vars (`XDG_CONFIG_HOME`, `JWT_HACK_WORDLIST_DIR`) and the four actual config keys; fixed the macOS config path.
- **scripting-automation** — Fixed exit-code claims and rewrote the bash/python examples to parse `--json` output instead of relying on exit status.
- **introduction** — Listed all supported algorithms (adds PS256/384/512, ES512, EdDSA).
- **installation** — `--version` prints the version only, not the banner.

## Verification

`hwaro build` succeeds (27 pages rendered). All changes cross-checked against `src/cmd/*`, `src/config.rs`, `src/payload/mod.rs`, and `src/jwt/mod.rs`.