### PR TITLE
fix(crack): harden brute-force keyspace math against panics

### DIFF
--- a/src/crack/brute.rs
+++ b/src/crack/brute.rs
@@ -113,8 +113,7 @@ pub fn generate_bruteforce_payloads(
     // saturates rather than truncates when the u64 total exceeds `usize` (32-bit).
     let charset_len = chars.chars().count();
     let total_combinations: usize =
-        usize::try_from(estimate_combinations(charset_len, 1, max_length))
-            .unwrap_or(usize::MAX);
+        usize::try_from(estimate_combinations(charset_len, 1, max_length)).unwrap_or(usize::MAX);
 
     let completed = Arc::new(AtomicUsize::new(0));
 

--- a/src/crack/brute.rs
+++ b/src/crack/brute.rs
@@ -105,11 +105,16 @@ pub fn generate_bruteforce_payloads(
     const CHUNK_SIZE: usize = 10000; // Chunk size optimized for memory usage and parallelism
     let result = Arc::new(Mutex::new(Vec::new()));
 
-    // Calculate total number of combinations for accurate progress reporting
+    // Calculate total number of combinations for accurate progress reporting.
+    // Reuse the saturating `estimate_combinations` helper instead of a plain
+    // `pow`/`sum`, which would overflow `usize` for a large charset or
+    // `max_length` — panicking in debug/test builds and silently wrapping in
+    // release, corrupting the progress denominator. `try_from(..).unwrap_or(MAX)`
+    // saturates rather than truncates when the u64 total exceeds `usize` (32-bit).
     let charset_len = chars.chars().count();
-    let total_combinations: usize = (1..=max_length)
-        .map(|len| charset_len.pow(len as u32))
-        .sum();
+    let total_combinations: usize =
+        usize::try_from(estimate_combinations(charset_len, 1, max_length))
+            .unwrap_or(usize::MAX);
 
     let completed = Arc::new(AtomicUsize::new(0));
 
@@ -177,7 +182,19 @@ pub const MAX_BRUTE_LENGTH: usize = 64;
 pub fn write_candidate_bytes(idx: u64, char_bytes: &[Vec<u8>], length: usize, out: &mut Vec<u8>) {
     debug_assert!(length <= MAX_BRUTE_LENGTH);
     out.clear();
+    // `indices` is a fixed [_; MAX_BRUTE_LENGTH] buffer; indexing it with a
+    // `length` past that bound is an out-of-bounds panic even in release builds.
+    // All callers already clamp `length`, but guard the public API regardless.
+    if length > MAX_BRUTE_LENGTH {
+        return;
+    }
     let charset_size = char_bytes.len() as u64;
+    // An empty charset has no candidates to write; guarding here avoids a
+    // division-by-zero panic (`n % 0`) if this public helper is called with an
+    // empty `char_bytes` and a non-zero `length`.
+    if charset_size == 0 {
+        return;
+    }
     let mut indices = [0u32; MAX_BRUTE_LENGTH];
     let mut n = idx;
     for i in (0..length).rev() {
@@ -316,6 +333,15 @@ mod tests {
         write_candidate_bytes(3, &char_bytes, 2, &mut buf);
         // idx 3 = 11 in base-2 → "글글"
         assert_eq!(buf.as_slice(), "글글".as_bytes());
+    }
+
+    #[test]
+    fn test_write_candidate_bytes_empty_charset_no_panic() {
+        // An empty charset must not divide by zero (`n % 0`); it produces no output.
+        let char_bytes: Vec<Vec<u8>> = Vec::new();
+        let mut buf = vec![0xAA];
+        write_candidate_bytes(0, &char_bytes, 3, &mut buf);
+        assert!(buf.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes three crash-prone spots in the brute-force helpers (`src/crack/brute.rs`). These were the remaining places in a well-hardened codebase where degenerate or large inputs could panic — the rest of the module already uses saturating arithmetic and length guards, and these were the outliers.

## Fixes

1. **Integer-overflow panic** in `generate_bruteforce_payloads`: the progress-total denominator used a plain `charset_len.pow(len)` + `.sum()`. For a large charset or `max_length` this overflows `usize` — a panic in debug/test builds and a silent wrap in release (corrupting the progress percentage). Now reuses the existing saturating `estimate_combinations` helper and saturates the `u64`→`usize` conversion (`try_from(..).unwrap_or(usize::MAX)`) instead of truncating on 32-bit targets.

2. **Division-by-zero panic** in `write_candidate_bytes`: an empty charset makes `charset_size == 0`, so `n % charset_size` panics. Added an early return.

3. **Out-of-bounds panic** in `write_candidate_bytes`: the fixed `[0u32; MAX_BRUTE_LENGTH]` buffer would be indexed out of bounds (a panic even in release) when `length > MAX_BRUTE_LENGTH`. Only a `debug_assert` guarded it; added a release-safe early return.

## Testing

- Added a regression test for the empty-charset path.
- All 566 existing tests pass; `cargo clippy --all-targets` is clean.
- Reviewed via `/code-review` (xhigh): no correctness bugs; the two low-severity notes were addressed (reuse `estimate_combinations`, saturating conversion).

## Notes

Production cracking uses the streaming `write_candidate_bytes` path; the `generate_bruteforce_payloads` overflow fix hardens a public library API that is otherwise only reached from tests. The guards are defense-in-depth for the public brute-force API surface.