### PR TITLE
fix(interfaces): harden config dir, server bind, and shell title bar

### DIFF
--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -731,6 +731,34 @@ fn build_router(api_key: Option<String>) -> Router {
     router.layer(from_fn_with_state(api_key, api_key_middleware))
 }
 
+/// Bind the server's TCP listener. Returns a clean `io::Error` instead of
+/// panicking so the caller can report the common "address already in use" /
+/// invalid-address cases without a backtrace.
+async fn bind_listener(addr: &str) -> std::io::Result<tokio::net::TcpListener> {
+    tokio::net::TcpListener::bind(addr).await
+}
+
+/// Bind `addr` and serve `app`. Bind and serve failures are reported as clean
+/// error lines and exit non-zero, replacing the previous `.expect(...)` panics
+/// (which, under the release profile's `panic = "abort"`, printed a Rust panic +
+/// backtrace note for an everyday "port already in use" situation).
+async fn serve_app(app: Router, addr: &str) {
+    let listener = match bind_listener(addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            utils::log_error(format!("Failed to bind to {addr}: {e}"));
+            std::process::exit(1);
+        }
+    };
+
+    utils::log_success(format!("Server started successfully on {}", addr));
+
+    if let Err(e) = axum::serve(listener, app).await {
+        utils::log_error(format!("Server error: {e}"));
+        std::process::exit(1);
+    }
+}
+
 /// Execute the server command
 pub async fn execute(host: &str, port: u16) {
     utils::log_info("Starting JWT-HACK REST API server".to_string());
@@ -746,15 +774,7 @@ pub async fn execute(host: &str, port: u16) {
 
     let app = build_router(None);
     let addr = format!("{}:{}", host, port);
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .expect("Failed to bind to address");
-
-    utils::log_success(format!("Server started successfully on {}", addr));
-
-    axum::serve(listener, app)
-        .await
-        .expect("Server failed to start");
+    serve_app(app, &addr).await;
 }
 
 pub async fn execute_with_api_key(host: &str, port: u16, api_key: &str) {
@@ -772,15 +792,7 @@ pub async fn execute_with_api_key(host: &str, port: u16, api_key: &str) {
 
     let app = build_router(Some(api_key.to_string()));
     let addr = format!("{}:{}", host, port);
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .expect("Failed to bind to address");
-
-    utils::log_success(format!("Server started successfully on {}", addr));
-
-    axum::serve(listener, app)
-        .await
-        .expect("Server failed to start");
+    serve_app(app, &addr).await;
 }
 
 #[cfg(test)]
@@ -913,6 +925,37 @@ mod tests {
         let response = result.unwrap().0;
         assert!(response.success);
         assert_eq!(response.valid, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_bind_listener_ok_on_ephemeral_port() {
+        // Binding an ephemeral port succeeds and yields a real local address.
+        let listener = bind_listener("127.0.0.1:0")
+            .await
+            .expect("ephemeral bind should succeed");
+        assert!(listener.local_addr().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_bind_listener_reports_error_instead_of_panicking() {
+        // Re-binding an already-bound address must return Err (which serve_app turns
+        // into a clean error line) rather than panic as the old `.expect` did.
+        let first = bind_listener("127.0.0.1:0")
+            .await
+            .expect("first bind should succeed");
+        let addr = first.local_addr().expect("addr");
+        let second = bind_listener(&addr.to_string()).await;
+        assert!(
+            second.is_err(),
+            "re-binding an in-use port must error, not panic"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bind_listener_rejects_invalid_address() {
+        // A malformed host:port must surface as an error, never a panic.
+        let result = bind_listener("not a valid addr").await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/cmd/shell/ui.rs
+++ b/src/cmd/shell/ui.rs
@@ -48,6 +48,17 @@ pub fn render(frame: &mut Frame, app: &App) {
     frame.set_cursor_position(Position::new(cursor_x.min(max_x), cursor_y));
 }
 
+/// Columns of horizontal rule that fill the title bar between the fixed left
+/// label and the right-aligned session indicators.
+///
+/// Both sides are measured in visible terminal columns (`chars().count()`) rather
+/// than UTF-8 byte length so multi-byte glyphs (`│`, `●`, `○`) don't shrink the
+/// rule. Saturating so a narrow terminal never underflows.
+fn title_rule_width(area_width: u16, left: &str, right: &str) -> u16 {
+    let used = left.chars().count().saturating_add(right.chars().count());
+    area_width.saturating_sub(used as u16)
+}
+
 fn render_title_bar(frame: &mut Frame, app: &App, area: Rect) {
     let left = Span::styled(
         " jwt-hack shell ",
@@ -93,9 +104,11 @@ fn render_title_bar(frame: &mut Frame, app: &App, area: Rect) {
     );
 
     let left_text = " jwt-hack shell ";
-    let padding_len = area
-        .width
-        .saturating_sub(left_text.len() as u16 + right_text.len() as u16);
+    // Measure both sides in *visible columns*, not UTF-8 bytes: `right_text`
+    // contains box-drawing (`│`) and status (`●`/`○`) glyphs that are 3 bytes but
+    // 1 column each, so `str::len()` over-counted the right side by 6 columns and
+    // the dim rule fell short, leaving a gap before the right-aligned indicators.
+    let padding_len = title_rule_width(area.width, left_text, &right_text);
     let padding = Span::raw("─".repeat(padding_len as usize));
 
     let title_line = Line::from(vec![
@@ -252,6 +265,38 @@ mod tests {
             mode: AppMode::Normal,
             should_quit: false,
         }
+    }
+
+    #[test]
+    fn test_title_rule_width_counts_visible_columns_not_bytes() {
+        // The right side mixes ASCII with 3-byte, 1-column glyphs (│, ●). The rule
+        // width must be computed from visible columns so it fills the gap exactly.
+        let left = " jwt-hack shell "; // 16 columns, all ASCII
+        let right = " HS256 │ JWT │ ●secret "; // 23 columns, 29 bytes
+        let width = 80u16;
+
+        let cols = title_rule_width(width, left, right);
+        // Correct: 80 - 16 - 23 = 41 columns of rule.
+        assert_eq!(cols, 41);
+
+        // Rule + both sides must exactly fill the terminal width (no gap/overflow).
+        assert_eq!(
+            cols as usize + left.chars().count() + right.chars().count(),
+            width as usize
+        );
+
+        // Guard against the old byte-length regression, which would have used 29.
+        let byte_based = width.saturating_sub(left.len() as u16 + right.len() as u16);
+        assert_ne!(cols, byte_based);
+    }
+
+    #[test]
+    fn test_title_rule_width_saturates_on_narrow_terminal() {
+        // A terminal narrower than the fixed labels must not underflow.
+        assert_eq!(
+            title_rule_width(4, " jwt-hack shell ", " HS256 │ JWT │ ●secret "),
+            0
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,10 +52,28 @@ impl Config {
 
     /// Get the default config directory path using XDG specification
     pub fn default_config_dir() -> Option<PathBuf> {
-        // Check XDG_CONFIG_HOME environment variable first
-        if let Ok(xdg_config_home) = std::env::var("XDG_CONFIG_HOME") {
-            let path = PathBuf::from(xdg_config_home).join("jwt-hack");
-            return Some(path);
+        Self::resolve_config_dir(std::env::var_os("XDG_CONFIG_HOME").as_deref())
+    }
+
+    /// Resolve the config directory from a supplied `XDG_CONFIG_HOME` value.
+    ///
+    /// Honors `XDG_CONFIG_HOME` only when it names an *absolute* path. The XDG Base
+    /// Directory spec requires these variables to be absolute and says an empty
+    /// value must be treated as unset (falling back to the platform default).
+    /// Without this guard an empty `XDG_CONFIG_HOME=""` makes
+    /// `PathBuf::from("").join("jwt-hack")` resolve to a CWD-relative `jwt-hack`
+    /// directory, so config/history would be read from and written to whatever
+    /// directory the tool happens to be launched in — and `Config::load` could
+    /// silently pick up an attacker-planted `./jwt-hack/config.toml`.
+    ///
+    /// Split out from the env lookup so it is unit-testable without mutating the
+    /// process-global environment (which would data-race parallel tests).
+    fn resolve_config_dir(xdg_config_home: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+        if let Some(xdg_config_home) = xdg_config_home {
+            let path = PathBuf::from(xdg_config_home);
+            if path.is_absolute() {
+                return Some(path.join("jwt-hack"));
+            }
         }
 
         // Fall back to platform-specific config directory
@@ -125,7 +143,60 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_xdg_config_home_absolute_is_honored() {
+        let abs = if cfg!(windows) {
+            "C:\\custom\\xdg"
+        } else {
+            "/custom/xdg"
+        };
+        let dir =
+            Config::resolve_config_dir(Some(OsStr::new(abs))).expect("absolute XDG yields a dir");
+        assert_eq!(dir, PathBuf::from(abs).join("jwt-hack"));
+    }
+
+    #[test]
+    fn test_empty_xdg_config_home_falls_back_to_absolute_default() {
+        // An empty XDG_CONFIG_HOME must NOT resolve to a CWD-relative `jwt-hack`
+        // directory; it should be treated as unset and fall back to the platform
+        // default (which is absolute).
+        if let Some(dir) = Config::resolve_config_dir(Some(OsStr::new(""))) {
+            assert!(
+                dir.is_absolute(),
+                "empty XDG_CONFIG_HOME must not produce a relative config dir, got {dir:?}"
+            );
+            assert_ne!(dir, PathBuf::from("jwt-hack"));
+        }
+    }
+
+    #[test]
+    fn test_relative_xdg_config_home_is_ignored() {
+        // A relative XDG_CONFIG_HOME is invalid per the XDG spec and must be ignored
+        // rather than producing a config dir relative to the current directory.
+        if let Some(dir) = Config::resolve_config_dir(Some(OsStr::new("relative/path"))) {
+            assert!(
+                dir.is_absolute(),
+                "relative XDG_CONFIG_HOME must be ignored, got {dir:?}"
+            );
+            assert!(!dir.starts_with("relative"));
+        }
+    }
+
+    #[test]
+    fn test_unset_xdg_config_home_uses_platform_default() {
+        // With no XDG override, the resolver must produce an absolute platform
+        // default (or None on an unusual host), never a relative path.
+        if let Some(dir) = Config::resolve_config_dir(None) {
+            assert!(
+                dir.is_absolute(),
+                "platform default must be absolute, got {dir:?}"
+            );
+            assert!(dir.ends_with("jwt-hack"));
+        }
+    }
 
     #[test]
     fn test_default_config() {


### PR DESCRIPTION
## Summary

Bug-hunting pass over the **interfaces** layer (REST server, interactive shell, config). Found and fixed three real defects, each with regression tests. No contract files touched; `--json`/data-line output is unaffected.

## Bugs fixed

### 1. `config`: empty/relative `XDG_CONFIG_HOME` resolves to a CWD-relative config dir
`Config::default_config_dir()` did `PathBuf::from(std::env::var("XDG_CONFIG_HOME")?).join("jwt-hack")`. A **set-but-empty** `XDG_CONFIG_HOME=""` therefore resolved to the relative path `jwt-hack` (and a relative value like `foo` to `foo/jwt-hack`).

Reproduction:
```
$ XDG_CONFIG_HOME="" jwt-hack ...   # config dir becomes ./jwt-hack (relative to CWD)
```
This violates the XDG Base Directory spec (paths must be absolute; an empty value is treated as unset → platform default). Consequences: config file, shell history, and `ensure_config_dir` land in whatever directory the tool was launched from, and `Config::load` could silently pick up an attacker-planted `./jwt-hack/config.toml`.

**Fix:** honor `XDG_CONFIG_HOME` only when it is an absolute path; otherwise fall back to `dirs::config_dir()`. Logic extracted into a pure `resolve_config_dir(Option<&OsStr>)` helper so it's unit-testable without mutating the process-global environment (which would data-race parallel tests in other modules, e.g. `History::new`).

### 2. `server`: bind/serve failures panic instead of reporting cleanly
`execute`/`execute_with_api_key` used `.expect("Failed to bind to address")` and `.expect("Server failed to start")`. A routine "port already in use" produced a Rust panic + backtrace note, aborting under the release profile's `panic = "abort"`.

**Fix:** a shared `serve_app` reports a clean error line (`Failed to bind to <addr>: <e>`) and exits non-zero. The bind is factored into a testable `bind_listener` returning `io::Result`.

### 3. `shell` UI: title-bar rule width counted bytes, not columns
The title bar computed its horizontal-rule width from `str::len()` (UTF-8 bytes). The right-side indicators contain 3-byte/1-column glyphs (`│`, `●`, `○`), so the rule was ~6 columns too short, leaving a visible gap before the right-aligned indicators — the same byte-vs-column pitfall already documented and fixed in `printing/theme.rs`.

**Fix:** measure both sides in visible columns via a testable `title_rule_width` helper.

## Tests
- `config`: absolute honored; empty falls back to an absolute default; relative ignored; unset → platform default.
- `server`: `bind_listener` succeeds on an ephemeral port, returns `Err` (not panic) when re-binding an in-use port, and rejects a malformed address.
- `shell`: `title_rule_width` uses visible columns (fills width exactly, differs from the byte-based value) and saturates on a narrow terminal.

## Verification
- `cargo test` — all pass (165 lib + 405 bin + e2e/interop)
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — 0 warnings

